### PR TITLE
Fixed example of ADF deployment script

### DIFF
--- a/DeploymentTools/DataFactory/DeployProcFwkComponents.ps1
+++ b/DeploymentTools/DataFactory/DeployProcFwkComponents.ps1
@@ -1,10 +1,16 @@
-﻿Param(
+﻿function Publish-procfwkadf 
+{
+Param(
     [Parameter(Mandatory)]
     [string]$resourceGroupName,
     [Parameter(Mandatory)]
     [string]$dataFactoryName,
     [Parameter(Mandatory)]
-    [string]$region
+    [string]$region,
+    [Parameter(Mandatory)]
+    [string]$adfPath,
+    [Parameter(Mandatory)]
+    [string]$scriptPath
 )
 
 #SPN for deploying ADF:
@@ -33,14 +39,10 @@ if ($spId) {
 }
 Get-AzContext
 
-#$VerbosePreference = 'Continue'
-$ErrorActionPreference = 'Stop'
-
 # Get Deployment Objects and Params files
-$scriptPath = Join-Path -Path (Get-Location) -ChildPath "\DeploymentTools\DataFactory"
 $deploymentFilePath = Join-Path -Path $scriptPath -ChildPath "ProcFwkComponents.json"
 $configFilePath = Join-Path -Path $scriptPath -ChildPath "config-all.csv"
-$Env:SQLDatabase = "<secretKeyToDbConnectionString>"
+$Env:SQLDatabase = "secretKeyToDbConnectionString"
 
 $opt = New-AdfPublishOption
 $deploymentObject = (Get-Content $deploymentFilePath) | ConvertFrom-Json 
@@ -51,15 +53,28 @@ $objectsToInclude | ForEach-Object {
 }
 
 # Deployment of ADF
-$AdfPath = Join-Path -Path (Get-Location) -ChildPath "DataFactory"
 $opt.CreateNewInstance = $true
 $opt.DeleteNotInSource = $false
 $opt.StopStartTriggers = $true
-Publish-AdfV2FromJson -RootFolder $AdfPath `
+Publish-AdfV2FromJson -RootFolder $adfPath `
     -ResourceGroupName $resourceGroupName `
     -DataFactoryName $dataFactoryName `
     -Location $region `
     -Option $opt `
     -Stage $configFilePath
+
+}
+
+
+# Run function
+$VerbosePreference = 'Continue'
+$ErrorActionPreference = 'Stop'
+
+$scriptPath = Join-Path -Path (Get-Location) -ChildPath "\DeploymentTools\DataFactory"
+$AdfPath = Join-Path -Path (Get-Location) -ChildPath "DataFactory"
+
+Publish-procfwkadf  -resourceGroupName 'rg-pademo' -dataFactoryName 'adf-metadata-driven-proc' -region 'uksouth' `
+    -adfPath "$AdfPath" -scriptPath "$scriptPath"
+
 
 

--- a/DeploymentTools/DataFactory/ProcFwkComponents.json
+++ b/DeploymentTools/DataFactory/ProcFwkComponents.json
@@ -11,7 +11,9 @@
     "/pipeline/04-Infant.json",
     "/pipeline/03-Child.json",
     "/pipeline/02-Parent.json",
-    "/pipeline/01-Grandparent.json"
+    "/pipeline/01-Grandparent.json",
+    "/pipeline/Throw Exception.json",
+    "/pipeline/Check For Running Pipeline.json"
   ],
   "triggers": [
     "/trigger/FunctionalTestingTrigger.json"


### PR DESCRIPTION
This change is fixing the deployment of ADF due to lack of dependant objects in the list of objects to be deployed.
Using this opportunity I wrapped up the code into the function and run it at the end of the script.
The issue might be related to the issue raised in here:
https://docs.microsoft.com/en-us/answers/questions/147304/could-not-find-object-linkedservicesupportdatabase.html#answer-form
but also was raised by @pfiadeiro to us via Twitter.