### PR TITLE
Issue 87 - Switch Email Alerting Call to Use Utils Pipeline 

### DIFF
--- a/Check For Running Pipeline.json
+++ b/Check For Running Pipeline.json
@@ -1,0 +1,402 @@
+{
+  "name": "Check For Running Pipeline",
+  "properties": {
+    "description": "For a given pipeline and optional batch name establish if a pipeline run is already in progress. Throw an exception if it it.",
+    "activities": [
+      {
+        "name": "Get Subscription",
+        "description": "Use the Azure Management API to return the current subscription.",
+        "type": "WebActivity",
+        "dependsOn": [],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "url": "https://management.azure.com/subscriptions?api-version=2020-01-01",
+          "method": "GET",
+          "authentication": {
+            "type": "MSI",
+            "resource": "https://management.core.windows.net/"
+          }
+        }
+      },
+      {
+        "name": "Get Pipeline Runs",
+        "description": "Use the Azure Management API to return a list of pipeline runs within the given time window.",
+        "type": "WebActivity",
+        "dependsOn": [
+          {
+            "activity": "Get Query Run Days Value",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "Check for Valid Pipeline Name",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "url": {
+            "value": "https://management.azure.com/subscriptions/@{variables('SubscriptionId')}/resourceGroups/@{activity('Get Resource Group').output.firstRow.PropertyValue}/providers/Microsoft.DataFactory/factories/@{pipeline().DataFactory}/queryPipelineRuns?api-version=2018-06-01",
+            "type": "Expression"
+          },
+          "method": "POST",
+          "body": {
+            "value": "{\n  \"lastUpdatedAfter\": \"@{adddays(utcnow(),int(activity('Get Query Run Days Value').output.firstRow.PropertyValue))}\",\n  \"lastUpdatedBefore\": \"@{utcnow()}\",\n  \"filters\": [\n    {\n      \"operand\": \"PipelineName\",\n      \"operator\": \"Equals\",\n      \"values\": [\n        \"@{pipeline().parameters.PipelineName}\"\n      ]\n    }\n  ]\n}",
+            "type": "Expression"
+          },
+          "authentication": {
+            "type": "MSI",
+            "resource": "https://management.core.windows.net/"
+          }
+        }
+      },
+      {
+        "name": "Set Parsed Subscription",
+        "description": "Parse the subscription string value to return just the subscription ID.",
+        "type": "SetVariable",
+        "dependsOn": [
+          {
+            "activity": "Get Subscription",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "variableName": "SubscriptionId",
+          "value": {
+            "value": "@replace(activity('Get Subscription').output.value[0].id,'/subscriptions/','')",
+            "type": "Expression"
+          }
+        }
+      },
+      {
+        "name": "Filter Running Pipelines",
+        "description": "Filter the pipeline runs results for pipelines that exclude the current triggered run and that are currently running (in progress or queued).",
+        "type": "Filter",
+        "dependsOn": [
+          {
+            "activity": "Get Pipeline Runs",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "items": {
+            "value": "@activity('Get Pipeline Runs').output.value",
+            "type": "Expression"
+          },
+          "condition": {
+            "value": "@and(not(equals(item().runId,pipeline().parameters.ThisRunId)),or(equals(item().status,'InProgress'),equals(item().status,'Queued')))",
+            "type": "Expression"
+          }
+        }
+      },
+      {
+        "name": "Get Resource Group",
+        "description": "Using the metadata properties table return the framework factory resource group name.",
+        "type": "Lookup",
+        "dependsOn": [],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "source": {
+            "type": "AzureSqlSource",
+            "sqlReaderStoredProcedureName": "[procfwk].[GetPropertyValue]",
+            "storedProcedureParameters": {
+              "PropertyName": {
+                "type": "String",
+                "value": "FrameworkFactoryResourceGroup"
+              }
+            },
+            "queryTimeout": "02:00:00",
+            "partitionOption": "None"
+          },
+          "dataset": {
+            "referenceName": "GetSetMetadata",
+            "type": "DatasetReference"
+          }
+        }
+      },
+      {
+        "name": "Get Query Run Days Value",
+        "description": "Using the metadata properties table return the run days value to provide the API request with a date range for pipeline executions.",
+        "type": "Lookup",
+        "dependsOn": [],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "source": {
+            "type": "AzureSqlSource",
+            "sqlReaderStoredProcedureName": "[procfwk].[GetPropertyValue]",
+            "storedProcedureParameters": {
+              "PropertyName": {
+                "type": "String",
+                "value": "PreviousPipelineRunsQueryRange"
+              }
+            },
+            "queryTimeout": "02:00:00",
+            "partitionOption": "None"
+          },
+          "dataset": {
+            "referenceName": "GetSetMetadata",
+            "type": "DatasetReference"
+          }
+        }
+      },
+      {
+        "name": "If Pipeline Is Running",
+        "description": "If the running pipeline count is greater than or equal to one.\nTrue = raise an exception.",
+        "type": "IfCondition",
+        "dependsOn": [
+          {
+            "activity": "If Using Batch Executions",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "expression": {
+            "value": "@greaterOrEquals(int(variables('RunCount')),1)",
+            "type": "Expression"
+          },
+          "ifTrueActivities": [
+            {
+              "name": "Throw Exception - Pipeline Running",
+              "description": "Using the utils pipeline raise an exception to stop the new trigger while a run is already in progress.",
+              "type": "ExecutePipeline",
+              "dependsOn": [],
+              "userProperties": [],
+              "typeProperties": {
+                "pipeline": {
+                  "referenceName": "Throw Exception",
+                  "type": "PipelineReference"
+                },
+                "waitOnCompletion": true,
+                "parameters": {
+                  "Message": {
+                    "value": "@concat('Provided pipeline name (',pipeline().parameters.PipelineName,') still has a run in progress or queued given the query range parameters set in the properties table.')",
+                    "type": "Expression"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "Get Execution Batch Status",
+        "description": "Using the metadata properties table return the flag to indicate if batch execution setting are enabled or disabled.",
+        "type": "Lookup",
+        "dependsOn": [],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "source": {
+            "type": "AzureSqlSource",
+            "sqlReaderStoredProcedureName": "[procfwk].[GetPropertyValue]",
+            "storedProcedureParameters": {
+              "PropertyName": {
+                "type": "String",
+                "value": "UseExecutionBatches"
+              }
+            },
+            "queryTimeout": "02:00:00",
+            "partitionOption": "None"
+          },
+          "dataset": {
+            "referenceName": "GetSetMetadata",
+            "type": "DatasetReference"
+          }
+        }
+      },
+      {
+        "name": "If Using Batch Executions",
+        "description": "True = batch executions are enabled.\nFalse = batch execution are disabled.",
+        "type": "IfCondition",
+        "dependsOn": [
+          {
+            "activity": "Get Execution Batch Status",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "Filter Running Pipelines",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "expression": {
+            "value": "@equals(activity('Get Execution Batch Status').output.firstRow.PropertyValue,string(1))",
+            "type": "Expression"
+          },
+          "ifFalseActivities": [
+            {
+              "name": "Set Run Count Without Batch",
+              "description": "Set the pipelines running count variable to be tested later.",
+              "type": "SetVariable",
+              "dependsOn": [],
+              "userProperties": [],
+              "typeProperties": {
+                "variableName": "RunCount",
+                "value": {
+                  "value": "@string(activity('Filter Running Pipelines').output.FilteredItemsCount)",
+                  "type": "Expression"
+                }
+              }
+            }
+          ],
+          "ifTrueActivities": [
+            {
+              "name": "Filter for Batch Name",
+              "description": "Further filter the return pipeline runs for any running pipelines with the same batch name value.",
+              "type": "Filter",
+              "dependsOn": [],
+              "userProperties": [],
+              "typeProperties": {
+                "items": {
+                  "value": "@activity('Filter Running Pipelines').output.value",
+                  "type": "Expression"
+                },
+                "condition": {
+                  "value": "@equals(item().parameters.BatchName,pipeline().parameters.BatchName)",
+                  "type": "Expression"
+                }
+              }
+            },
+            {
+              "name": "Set Run Count for Batch",
+              "description": "Set the resulting pipeline running count variable to be tested later.",
+              "type": "SetVariable",
+              "dependsOn": [
+                {
+                  "activity": "Filter for Batch Name",
+                  "dependencyConditions": [
+                    "Succeeded"
+                  ]
+                }
+              ],
+              "userProperties": [],
+              "typeProperties": {
+                "variableName": "RunCount",
+                "value": {
+                  "value": "@string(activity('Filter for Batch Name').output.FilteredItemsCount)",
+                  "type": "Expression"
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "Check for Valid Pipeline Name",
+        "description": "Use the Azure Management API to return and establish if the framework pipeline exists in the target Data Factory, including being deployed.",
+        "type": "WebActivity",
+        "dependsOn": [
+          {
+            "activity": "Set Parsed Subscription",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "Get Resource Group",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "url": {
+            "value": "https://management.azure.com/subscriptions/@{variables('SubscriptionId')}/resourceGroups/@{activity('Get Resource Group').output.firstRow.PropertyValue}/providers/Microsoft.DataFactory/factories/@{pipeline().DataFactory}/pipelines/@{pipeline().parameters.PipelineName}?api-version=2018-06-01",
+            "type": "Expression"
+          },
+          "method": "GET",
+          "authentication": {
+            "type": "MSI",
+            "resource": "https://management.core.windows.net/"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "BatchName": {
+        "type": "string",
+        "defaultValue": "NotUsed"
+      },
+      "PipelineName": {
+        "type": "string"
+      },
+      "ThisRunId": {
+        "type": "string"
+      }
+    },
+    "variables": {
+      "SubscriptionId": {
+        "type": "String"
+      },
+      "RunCount": {
+        "type": "String"
+      }
+    },
+    "folder": {
+      "name": "_ProcFwk/_ProcFwkUtils"
+    },
+    "annotations": [
+      "procfwk",
+      "Utils"
+    ]
+  }
+}

--- a/DataFactory/pipeline/04-Infant.json
+++ b/DataFactory/pipeline/04-Infant.json
@@ -1,1510 +1,1523 @@
 {
-	"name": "04-Infant",
-	"properties": {
-		"description": "ADF.procfwk infant pipeline used to check when the processing pipeline called by the Child completes and passes the resulting status back to the metadata database.",
-		"activities": [
-			{
-				"name": "Execute Worker Pipeline",
-				"description": "The lowest level executor with the metadata framework to call existing processing pipelines within Data Factory. The function called will block processing and wait for an outcome.",
-				"type": "AzureFunctionActivity",
-				"dependsOn": [
-					{
-						"activity": "Log Pipeline Running",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
-					{
-						"activity": "Get Pipeline Params",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.00:10:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": true
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"functionName": "ExecutePipeline",
-					"method": "POST",
-					"body": {
-						"value": "@concat('\n{\n\t\"tenantId\": \"',variables('WorkerTenantId'),'\",\n\t\"applicationId\": \"',variables('WorkerAppId'),'\",\n\t\"authenticationKey\": \"',variables('WorkerAppSecret'),'\",\n\t\"subscriptionId\": \"',variables('WorkerSubscriptionId'),'\",\n\t\"resourceGroup\": \"',variables('WorkerResourceGroup'),'\",\n\t\"factoryName\": \"',variables('WorkerDataFactoryName'),'\",\n\t\"pipelineName\": \"',variables('WorkerPipelineName'),'\"',activity('Get Pipeline Params').output.firstRow.Params,'\n}')",
-						"type": "Expression"
-					}
-				},
-				"linkedServiceName": {
-					"referenceName": "FrameworkFunctions",
-					"type": "LinkedServiceReference"
-				}
-			},
-			{
-				"name": "Get Pipeline Params",
-				"description": "Returns any parameters from metadata required for the processing pipeline being called. The output can be an empty string if no parameters are required.",
-				"type": "Lookup",
-				"dependsOn": [],
-				"policy": {
-					"timeout": "0.00:10:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"source": {
-						"type": "AzureSqlSource",
-						"sqlReaderStoredProcedureName": "[procfwk].[GetPipelineParameters]",
-						"storedProcedureParameters": {
-							"PipelineId": {
-								"type": "Int32",
-								"value": {
-									"value": "@pipeline().parameters.pipelineId",
-									"type": "Expression"
-								}
-							}
-						},
-						"queryTimeout": "02:00:00",
-						"partitionOption": "None"
-					},
-					"dataset": {
-						"referenceName": "GetSetMetadata",
-						"type": "DatasetReference"
-					}
-				}
-			},
-			{
-				"name": "Log Pipeline Running",
-				"description": "Sets the current pipeline with a status of running within the current execution database table.",
-				"type": "SqlServerStoredProcedure",
-				"dependsOn": [
-					{
-						"activity": "Is Target Worker Validate",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.00:10:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"storedProcedureName": "[procfwk].[SetLogPipelineRunning]",
-					"storedProcedureParameters": {
-						"ExecutionId": {
-							"value": {
-								"value": "@pipeline().parameters.ExecutionId",
-								"type": "Expression"
-							},
-							"type": "Guid"
-						},
-						"PipelineId": {
-							"value": {
-								"value": "@pipeline().parameters.pipelineId",
-								"type": "Expression"
-							},
-							"type": "Int32"
-						},
-						"StageId": {
-							"value": {
-								"value": "@pipeline().parameters.StageId",
-								"type": "Expression"
-							},
-							"type": "Int32"
-						}
-					}
-				},
-				"linkedServiceName": {
-					"referenceName": "SupportDatabase",
-					"type": "LinkedServiceReference"
-				}
-			},
-			{
-				"name": "Get Worker Authentication Details",
-				"description": "Return the SPN ID and Secret for the worker pipeline being executed. Called at this level as each pipeline can have a different SPN.",
-				"type": "Lookup",
-				"dependsOn": [],
-				"policy": {
-					"timeout": "0.00:10:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": true,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"source": {
-						"type": "AzureSqlSource",
-						"sqlReaderStoredProcedureName": "[procfwk].[GetWorkerAuthDetails]",
-						"storedProcedureParameters": {
-							"ExecutionId": {
-								"type": "Guid",
-								"value": {
-									"value": "@pipeline().parameters.executionId",
-									"type": "Expression"
-								}
-							},
-							"PipelineId": {
-								"type": "Int32",
-								"value": {
-									"value": "@pipeline().parameters.pipelineId",
-									"type": "Expression"
-								}
-							},
-							"StageId": {
-								"type": "Int32",
-								"value": {
-									"value": "@pipeline().parameters.stageId",
-									"type": "Expression"
-								}
-							}
-						},
-						"queryTimeout": "02:00:00",
-						"partitionOption": "None"
-					},
-					"dataset": {
-						"referenceName": "GetSetMetadata",
-						"type": "DatasetReference"
-					}
-				}
-			},
-			{
-				"name": "Log Execute Function Activity Failure",
-				"description": "Handle true failures from calling out to the Azure Function and update the current execution table accordingly so a restart can occur.",
-				"type": "SqlServerStoredProcedure",
-				"dependsOn": [
-					{
-						"activity": "Execute Worker Pipeline",
-						"dependencyConditions": [
-							"Failed"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.00:10:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"storedProcedureName": "[procfwk].[SetLogActivityFailed]",
-					"storedProcedureParameters": {
-						"ExecutionId": {
-							"value": {
-								"value": "@pipeline().parameters.ExecutionId",
-								"type": "Expression"
-							},
-							"type": "Guid"
-						},
-						"PipelineId": {
-							"value": {
-								"value": "@pipeline().parameters.pipelineId",
-								"type": "Expression"
-							},
-							"type": "Int32"
-						},
-						"StageId": {
-							"value": {
-								"value": "@pipeline().parameters.StageId",
-								"type": "Expression"
-							},
-							"type": "Int32"
-						},
-						"CallingActivity": {
-							"value": "ExecuteWorkerPipeline",
-							"type": "String"
-						}
-					}
-				},
-				"linkedServiceName": {
-					"referenceName": "SupportDatabase",
-					"type": "LinkedServiceReference"
-				}
-			},
-			{
-				"name": "Update Run Id",
-				"description": "Provide the actual ADF run ID back to the current execution table for long term logging and alignment between the metadata other Azure monitoring tools.",
-				"type": "SqlServerStoredProcedure",
-				"dependsOn": [
-					{
-						"activity": "Set Run Id",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.00:10:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"storedProcedureName": "[procfwk].[SetLogPipelineRunId]",
-					"storedProcedureParameters": {
-						"ExecutionId": {
-							"value": {
-								"value": "@pipeline().parameters.ExecutionId",
-								"type": "Expression"
-							},
-							"type": "Guid"
-						},
-						"PipelineId": {
-							"value": {
-								"value": "@pipeline().parameters.pipelineId",
-								"type": "Expression"
-							},
-							"type": "Int32"
-						},
-						"RunId": {
-							"value": {
-								"value": "@variables('WorkerRunId')",
-								"type": "Expression"
-							},
-							"type": "Guid"
-						},
-						"StageId": {
-							"value": {
-								"value": "@pipeline().parameters.StageId",
-								"type": "Expression"
-							},
-							"type": "Int32"
-						}
-					}
-				},
-				"linkedServiceName": {
-					"referenceName": "SupportDatabase",
-					"type": "LinkedServiceReference"
-				}
-			},
-			{
-				"name": "Check For Alerts",
-				"description": "Checks the properties tables and if any recipients in the database require alerts sending for the current pipeline ID.",
-				"type": "Lookup",
-				"dependsOn": [
-					{
-						"activity": "Update Run Id",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
-					{
-						"activity": "Set Pipeline Result",
-						"dependencyConditions": [
-							"Completed"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.00:10:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"source": {
-						"type": "AzureSqlSource",
-						"sqlReaderStoredProcedureName": "[procfwk].[CheckForEmailAlerts]",
-						"storedProcedureParameters": {
-							"PipelineId": {
-								"type": "Int32",
-								"value": {
-									"value": "@pipeline().parameters.pipelineId",
-									"type": "Expression"
-								}
-							}
-						},
-						"queryTimeout": "02:00:00",
-						"partitionOption": "None"
-					},
-					"dataset": {
-						"referenceName": "GetSetMetadata",
-						"type": "DatasetReference"
-					},
-					"firstRowOnly": true
-				}
-			},
-			{
-				"name": "Send Alerts",
-				"description": "True = alerts need sending.\nFalse = do nothing.",
-				"type": "IfCondition",
-				"dependsOn": [
-					{
-						"activity": "Check For Alerts",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"userProperties": [],
-				"typeProperties": {
-					"expression": {
-						"value": "@activity('Check For Alerts').output.firstRow.SendAlerts",
-						"type": "Expression"
-					},
-					"ifTrueActivities": [
-						{
-							"name": "Get Email Parts",
-							"description": "Return all required content from the metadata database to send an email alerting using the procfwk. The lookup returns the exact content for the function body request.",
-							"type": "Lookup",
-							"dependsOn": [],
-							"policy": {
-								"timeout": "0.00:10:00",
-								"retry": 0,
-								"retryIntervalInSeconds": 30,
-								"secureOutput": true,
-								"secureInput": false
-							},
-							"userProperties": [],
-							"typeProperties": {
-								"source": {
-									"type": "AzureSqlSource",
-									"sqlReaderStoredProcedureName": "[procfwk].[GetEmailAlertParts]",
-									"storedProcedureParameters": {
-										"PipelineId": {
-											"type": "Int32",
-											"value": {
-												"value": "@pipeline().parameters.pipelineId",
-												"type": "Expression"
-											}
-										}
-									},
-									"queryTimeout": "02:00:00",
-									"partitionOption": "None"
-								},
-								"dataset": {
-									"referenceName": "GetSetMetadata",
-									"type": "DatasetReference"
-								},
-								"firstRowOnly": true
-							}
-						},
-						{
-							"name": "Send Email",
-							"description": "Use an Azure Function to perform an SMTP client email send operation.",
-							"type": "AzureFunctionActivity",
-							"dependsOn": [
-								{
-									"activity": "Get Email Parts",
-									"dependencyConditions": [
-										"Succeeded"
-									]
-								}
-							],
-							"policy": {
-								"timeout": "0.00:10:00",
-								"retry": 0,
-								"retryIntervalInSeconds": 30,
-								"secureOutput": false,
-								"secureInput": true
-							},
-							"userProperties": [],
-							"typeProperties": {
-								"functionName": "SendEmail",
-								"method": "POST",
-								"body": {
-									"value": "@activity('Get Email Parts').output.firstRow",
-									"type": "Expression"
-								}
-							},
-							"linkedServiceName": {
-								"referenceName": "FrameworkFunctions",
-								"type": "LinkedServiceReference"
-							}
-						}
-					]
-				}
-			},
-			{
-				"name": "Wait Until Pipeline Completes",
-				"description": "Loops until the Worker pipeline called completes.\n\nSimple status:\n- Running = new iteration.\n- Done = break.",
-				"type": "Until",
-				"dependsOn": [
-					{
-						"activity": "Get Wait Duration",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
-					{
-						"activity": "Execute Worker Pipeline",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
-					{
-						"activity": "Set Run Id",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"userProperties": [],
-				"typeProperties": {
-					"expression": {
-						"value": "@variables('WorkerPipelineState')",
-						"type": "Expression"
-					},
-					"activities": [
-						{
-							"name": "Get Worker Pipeline Status",
-							"description": "Checks the status of a given processing pipeline and provides the value for the downstream framework activities to act upon.",
-							"type": "AzureFunctionActivity",
-							"dependsOn": [],
-							"policy": {
-								"timeout": "0.00:10:00",
-								"retry": 0,
-								"retryIntervalInSeconds": 30,
-								"secureOutput": false,
-								"secureInput": true
-							},
-							"userProperties": [],
-							"typeProperties": {
-								"functionName": "CheckPipelineStatus",
-								"method": "POST",
-								"body": {
-									"value": "@concat('\n{\n    \"tenantId\": \"',variables('WorkerTenantId'),'\",\n    \"applicationId\": \"',variables('WorkerAppId'),'\",\n    \"authenticationKey\": \"',variables('WorkerAppSecret'),'\",\n    \"subscriptionId\": \"',variables('WorkerSubscriptionId'),'\",\n    \"resourceGroup\": \"',variables('WorkerResourceGroup'),'\",\n    \"factoryName\": \"',variables('WorkerDataFactoryName'),'\",\n    \"pipelineName\": \"',variables('WorkerPipelineName'),'\",\n    \"runId\": \"',variables('WorkerRunId'),'\"\n}')",
-									"type": "Expression"
-								}
-							},
-							"linkedServiceName": {
-								"referenceName": "FrameworkFunctions",
-								"type": "LinkedServiceReference"
-							}
-						},
-						{
-							"name": "Wait If Running",
-							"description": "True = Do nothing.\nFalse = Wait, before the next iteration.",
-							"type": "IfCondition",
-							"dependsOn": [
-								{
-									"activity": "Set Worker State",
-									"dependencyConditions": [
-										"Succeeded"
-									]
-								}
-							],
-							"userProperties": [],
-							"typeProperties": {
-								"expression": {
-									"value": "@variables('WorkerPipelineState')",
-									"type": "Expression"
-								},
-								"ifFalseActivities": [
-									{
-										"name": "Wait for Pipeline",
-										"description": "The processing pipeline is still running so Wait before checking its status again.",
-										"type": "Wait",
-										"dependsOn": [],
-										"userProperties": [],
-										"typeProperties": {
-											"waitTimeInSeconds": {
-												"value": "@activity('Get Wait Duration').output.firstRow.PropertyValue",
-												"type": "Expression"
-											}
-										}
-									}
-								]
-							}
-						},
-						{
-							"name": "Set Last Check DateTime",
-							"description": "Update the current execution table with a date time from when the Worker pipeline status was last checked as part of the Until iterations.",
-							"type": "SqlServerStoredProcedure",
-							"dependsOn": [
-								{
-									"activity": "Get Worker Pipeline Status",
-									"dependencyConditions": [
-										"Succeeded"
-									]
-								}
-							],
-							"policy": {
-								"timeout": "0.00:10:00",
-								"retry": 0,
-								"retryIntervalInSeconds": 30,
-								"secureOutput": false,
-								"secureInput": false
-							},
-							"userProperties": [],
-							"typeProperties": {
-								"storedProcedureName": "[procfwk].[SetLogPipelineLastStatusCheck]",
-								"storedProcedureParameters": {
-									"ExecutionId": {
-										"value": {
-											"value": "@pipeline().parameters.executionId",
-											"type": "Expression"
-										},
-										"type": "Guid"
-									},
-									"PipelineId": {
-										"value": {
-											"value": "@pipeline().parameters.pipelineId",
-											"type": "Expression"
-										},
-										"type": "Int32"
-									},
-									"StageId": {
-										"value": {
-											"value": "@pipeline().parameters.stageId",
-											"type": "Expression"
-										},
-										"type": "Int32"
-									}
-								}
-							},
-							"linkedServiceName": {
-								"referenceName": "SupportDatabase",
-								"type": "LinkedServiceReference"
-							}
-						},
-						{
-							"name": "Log Check Function Activity Failure",
-							"description": "Report to the current execution table that the framework pipeline activity has failed. This failure is outside of the scope of the framework and is probably related to a wider platform problem.",
-							"type": "SqlServerStoredProcedure",
-							"dependsOn": [
-								{
-									"activity": "Get Worker Pipeline Status",
-									"dependencyConditions": [
-										"Failed"
-									]
-								}
-							],
-							"policy": {
-								"timeout": "0.00:10:00",
-								"retry": 0,
-								"retryIntervalInSeconds": 30,
-								"secureOutput": false,
-								"secureInput": false
-							},
-							"userProperties": [],
-							"typeProperties": {
-								"storedProcedureName": "[procfwk].[SetLogActivityFailed]",
-								"storedProcedureParameters": {
-									"CallingActivity": {
-										"value": "GetWorkerPipelineStatus",
-										"type": "String"
-									},
-									"ExecutionId": {
-										"value": {
-											"value": "@pipeline().parameters.executionId",
-											"type": "Expression"
-										},
-										"type": "Guid"
-									},
-									"PipelineId": {
-										"value": {
-											"value": "@pipeline().parameters.pipelineId",
-											"type": "Expression"
-										},
-										"type": "Int32"
-									},
-									"StageId": {
-										"value": {
-											"value": "@pipeline().parameters.stageId",
-											"type": "Expression"
-										},
-										"type": "Int32"
-									}
-								}
-							},
-							"linkedServiceName": {
-								"referenceName": "SupportDatabase",
-								"type": "LinkedServiceReference"
-							}
-						},
-						{
-							"name": "Set Worker State",
-							"description": "Set the bool state of the Worker pipeline to be used by the Until and If expressions. True = Complete, False = Running.",
-							"type": "SetVariable",
-							"dependsOn": [
-								{
-									"activity": "Get Worker Pipeline Status",
-									"dependencyConditions": [
-										"Succeeded"
-									]
-								}
-							],
-							"userProperties": [],
-							"typeProperties": {
-								"variableName": "WorkerPipelineState",
-								"value": {
-									"value": "@equals('Done',activity('Get Worker Pipeline Status').output.SimpleStatus)",
-									"type": "Expression"
-								}
-							}
-						}
-					],
-					"timeout": "0.00:10:00"
-				}
-			},
-			{
-				"name": "Set Pipeline Result",
-				"description": "Receives the outcome from the function execution for a given processing pipeline and updates the current execution table with different pipelines status values depending on the result (case).",
-				"type": "Switch",
-				"dependsOn": [
-					{
-						"activity": "Wait Until Pipeline Completes",
-						"dependencyConditions": [
-							"Completed"
-						]
-					}
-				],
-				"userProperties": [],
-				"typeProperties": {
-					"on": {
-						"value": "@activity('Get Worker Pipeline Status').output.Status",
-						"type": "Expression"
-					},
-					"cases": [
-						{
-							"value": "Succeeded",
-							"activities": [
-								{
-									"name": "Pipeline Status Succeeded",
-									"description": "Updates the current execution table with a pipeline status of success if the function outcome is succeeded.",
-									"type": "SqlServerStoredProcedure",
-									"dependsOn": [],
-									"policy": {
-										"timeout": "0.00:10:00",
-										"retry": 0,
-										"retryIntervalInSeconds": 30,
-										"secureOutput": false,
-										"secureInput": false
-									},
-									"userProperties": [],
-									"typeProperties": {
-										"storedProcedureName": "[procfwk].[SetLogPipelineSuccess]",
-										"storedProcedureParameters": {
-											"ExecutionId": {
-												"value": {
-													"value": "@pipeline().parameters.executionId",
-													"type": "Expression"
-												},
-												"type": "Guid"
-											},
-											"PipelineId": {
-												"value": {
-													"value": "@pipeline().parameters.pipelineId",
-													"type": "Expression"
-												},
-												"type": "Int32"
-											},
-											"StageId": {
-												"value": {
-													"value": "@pipeline().parameters.stageId",
-													"type": "Expression"
-												},
-												"type": "Int32"
-											}
-										}
-									},
-									"linkedServiceName": {
-										"referenceName": "SupportDatabase",
-										"type": "LinkedServiceReference"
-									}
-								}
-							]
-						},
-						{
-							"value": "Failed",
-							"activities": [
-								{
-									"name": "Pipeline Status Failed",
-									"description": "Updates the current execution table with a pipeline status of failed if the function outcome is failed. Also blocks pipelines in the downstream execution stage.",
-									"type": "SqlServerStoredProcedure",
-									"dependsOn": [],
-									"policy": {
-										"timeout": "0.00:10:00",
-										"retry": 0,
-										"retryIntervalInSeconds": 30,
-										"secureOutput": false,
-										"secureInput": false
-									},
-									"userProperties": [],
-									"typeProperties": {
-										"storedProcedureName": "[procfwk].[SetLogPipelineFailed]",
-										"storedProcedureParameters": {
-											"ExecutionId": {
-												"value": {
-													"value": "@pipeline().parameters.executionId",
-													"type": "Expression"
-												},
-												"type": "Guid"
-											},
-											"PipelineId": {
-												"value": {
-													"value": "@pipeline().parameters.pipelineId",
-													"type": "Expression"
-												},
-												"type": "Int32"
-											},
-											"RunId": {
-												"value": {
-													"value": "@variables('WorkerRunId')",
-													"type": "Expression"
-												},
-												"type": "Guid"
-											},
-											"StageId": {
-												"value": {
-													"value": "@pipeline().parameters.stageId",
-													"type": "Expression"
-												},
-												"type": "Int32"
-											}
-										}
-									},
-									"linkedServiceName": {
-										"referenceName": "SupportDatabase",
-										"type": "LinkedServiceReference"
-									}
-								},
-								{
-									"name": "Get Worker Pipeline Error Details",
-									"description": "Get the activity error details for the run ID of the worker pipeline called. Returns an array of all errors.",
-									"type": "AzureFunctionActivity",
-									"dependsOn": [],
-									"policy": {
-										"timeout": "0.00:10:00",
-										"retry": 0,
-										"retryIntervalInSeconds": 30,
-										"secureOutput": false,
-										"secureInput": true
-									},
-									"userProperties": [],
-									"typeProperties": {
-										"functionName": "GetActivityErrors",
-										"method": "POST",
-										"body": {
-											"value": "@concat('\n{\n    \"tenantId\": \"',variables('WorkerTenantId'),'\",\n    \"applicationId\": \"',variables('WorkerAppId'),'\",\n    \"authenticationKey\": \"',variables('WorkerAppSecret'),'\",\n    \"subscriptionId\": \"',variables('WorkerSubscriptionId'),'\",\n    \"resourceGroup\": \"',variables('WorkerResourceGroup'),'\",\n    \"factoryName\": \"',variables('WorkerDataFactoryName'),'\",\n    \"pipelineName\": \"',variables('WorkerPipelineName'),'\",\n    \"runId\": \"',variables('WorkerRunId'),'\"\n}')",
-											"type": "Expression"
-										}
-									},
-									"linkedServiceName": {
-										"referenceName": "FrameworkFunctions",
-										"type": "LinkedServiceReference"
-									}
-								},
-								{
-									"name": "Log Error Details",
-									"description": "Parses pipeline error details and persists them to the metadata database error log table.",
-									"type": "SqlServerStoredProcedure",
-									"dependsOn": [
-										{
-											"activity": "Get Worker Pipeline Error Details",
-											"dependencyConditions": [
-												"Succeeded"
-											]
-										}
-									],
-									"policy": {
-										"timeout": "0.00:10:00",
-										"retry": 0,
-										"retryIntervalInSeconds": 30,
-										"secureOutput": false,
-										"secureInput": false
-									},
-									"userProperties": [],
-									"typeProperties": {
-										"storedProcedureName": "[procfwk].[SetErrorLogDetails]",
-										"storedProcedureParameters": {
-											"JsonErrorDetails": {
-												"value": {
-													"value": "@string(activity('Get Worker Pipeline Error Details').output)",
-													"type": "Expression"
-												},
-												"type": "String"
-											},
-											"LocalExecutionId": {
-												"value": {
-													"value": "@pipeline().parameters.executionId",
-													"type": "Expression"
-												},
-												"type": "Guid"
-											}
-										}
-									},
-									"linkedServiceName": {
-										"referenceName": "SupportDatabase",
-										"type": "LinkedServiceReference"
-									}
-								}
-							]
-						},
-						{
-							"value": "Cancelled",
-							"activities": [
-								{
-									"name": "Pipeline Status Cancelled",
-									"description": "Updates the current execution table with a pipeline status of cancelled if the function outcome is cancelled.",
-									"type": "SqlServerStoredProcedure",
-									"dependsOn": [],
-									"policy": {
-										"timeout": "0.00:10:00",
-										"retry": 0,
-										"retryIntervalInSeconds": 30,
-										"secureOutput": false,
-										"secureInput": false
-									},
-									"userProperties": [],
-									"typeProperties": {
-										"storedProcedureName": "[procfwk].[SetLogPipelineCancelled]",
-										"storedProcedureParameters": {
-											"ExecutionId": {
-												"value": {
-													"value": "@pipeline().parameters.executionId",
-													"type": "Expression"
-												},
-												"type": "Guid"
-											},
-											"PipelineId": {
-												"value": {
-													"value": "@pipeline().parameters.pipelineId",
-													"type": "Expression"
-												},
-												"type": "Int32"
-											},
-											"StageId": {
-												"value": {
-													"value": "@pipeline().parameters.stageId",
-													"type": "Expression"
-												},
-												"type": "Int32"
-											}
-										}
-									},
-									"linkedServiceName": {
-										"referenceName": "SupportDatabase",
-										"type": "LinkedServiceReference"
-									}
-								}
-							]
-						}
-					],
-					"defaultActivities": [
-						{
-							"name": "Pipeline Status Unknown",
-							"description": "Updates the current execution table with a pipeline status of unknown if the function returns an unexpected outcome.",
-							"type": "SqlServerStoredProcedure",
-							"dependsOn": [],
-							"policy": {
-								"timeout": "0.00:10:00",
-								"retry": 0,
-								"retryIntervalInSeconds": 30,
-								"secureOutput": false,
-								"secureInput": false
-							},
-							"userProperties": [],
-							"typeProperties": {
-								"storedProcedureName": "[procfwk].[SetLogPipelineUnknown]",
-								"storedProcedureParameters": {
-									"ExecutionId": {
-										"value": {
-											"value": "@pipeline().parameters.executionId",
-											"type": "Expression"
-										},
-										"type": "Guid"
-									},
-									"PipelineId": {
-										"value": {
-											"value": "@pipeline().parameters.pipelineId",
-											"type": "Expression"
-										},
-										"type": "Int32"
-									},
-									"StageId": {
-										"value": {
-											"value": "@pipeline().parameters.stageId",
-											"type": "Expression"
-										},
-										"type": "Int32"
-									}
-								}
-							},
-							"linkedServiceName": {
-								"referenceName": "SupportDatabase",
-								"type": "LinkedServiceReference"
-							}
-						}
-					]
-				}
-			},
-			{
-				"name": "Get Wait Duration",
-				"description": "Return wait duration in seconds from database properties table to be used during each Until iteration when the Worker pipeline is still running.",
-				"type": "Lookup",
-				"dependsOn": [],
-				"policy": {
-					"timeout": "0.00:10:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"source": {
-						"type": "AzureSqlSource",
-						"sqlReaderStoredProcedureName": "[procfwk].[GetPropertyValue]",
-						"storedProcedureParameters": {
-							"PropertyName": {
-								"type": "String",
-								"value": "PipelineStatusCheckDuration"
-							}
-						},
-						"queryTimeout": "02:00:00",
-						"partitionOption": "None"
-					},
-					"dataset": {
-						"referenceName": "GetSetMetadata",
-						"type": "DatasetReference"
-					}
-				}
-			},
-			{
-				"name": "Set App Id",
-				"description": "Set local variable from activity output once for value reuse in downstream activities.",
-				"type": "SetVariable",
-				"dependsOn": [
-					{
-						"activity": "Get Worker Authentication Details",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"userProperties": [],
-				"typeProperties": {
-					"variableName": "WorkerAppId",
-					"value": {
-						"value": "@activity('Get Worker Authentication Details').output.firstRow.AppId",
-						"type": "Expression"
-					}
-				}
-			},
-			{
-				"name": "Set App Secret",
-				"description": "Set local variable from activity output once for value reuse in downstream activities.",
-				"type": "SetVariable",
-				"dependsOn": [
-					{
-						"activity": "Get Worker Authentication Details",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"userProperties": [],
-				"typeProperties": {
-					"variableName": "WorkerAppSecret",
-					"value": {
-						"value": "@activity('Get Worker Authentication Details').output.firstRow.AppSecret",
-						"type": "Expression"
-					}
-				}
-			},
-			{
-				"name": "Set Run Id",
-				"description": "Set local variable from activity output once for value reuse in downstream activities.",
-				"type": "SetVariable",
-				"dependsOn": [
-					{
-						"activity": "Execute Worker Pipeline",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"userProperties": [],
-				"typeProperties": {
-					"variableName": "WorkerRunId",
-					"value": {
-						"value": "@activity('Execute Worker Pipeline').output.RunId",
-						"type": "Expression"
-					}
-				}
-			},
-			{
-				"name": "Get Worker Pipeline Details",
-				"description": "Return none sensitive worker pipeline information for metadata database. Including target data factory, pipeline name and resource group.",
-				"type": "Lookup",
-				"dependsOn": [],
-				"policy": {
-					"timeout": "0.00:10:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": true,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"source": {
-						"type": "AzureSqlSource",
-						"sqlReaderStoredProcedureName": "[procfwk].[GetWorkerPipelineDetails]",
-						"storedProcedureParameters": {
-							"ExecutionId": {
-								"type": "Guid",
-								"value": {
-									"value": "@pipeline().parameters.ExecutionId",
-									"type": "Expression"
-								}
-							},
-							"PipelineId": {
-								"type": "Int32",
-								"value": {
-									"value": "@pipeline().parameters.pipelineId",
-									"type": "Expression"
-								}
-							},
-							"StageId": {
-								"type": "Int32",
-								"value": {
-									"value": "@pipeline().parameters.stageId",
-									"type": "Expression"
-								}
-							}
-						},
-						"queryTimeout": "02:00:00",
-						"partitionOption": "None"
-					},
-					"dataset": {
-						"referenceName": "GetSetMetadata",
-						"type": "DatasetReference"
-					}
-				}
-			},
-			{
-				"name": "Set Tenant Id",
-				"description": "Set local variable from activity output once for value reuse in downstream activities.",
-				"type": "SetVariable",
-				"dependsOn": [
-					{
-						"activity": "Get Worker Authentication Details",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"userProperties": [],
-				"typeProperties": {
-					"variableName": "WorkerTenantId",
-					"value": {
-						"value": "@activity('Get Worker Authentication Details').output.firstRow.TenantId",
-						"type": "Expression"
-					}
-				}
-			},
-			{
-				"name": "Set Subscription Id",
-				"description": "Set local variable from activity output once for value reuse in downstream activities.",
-				"type": "SetVariable",
-				"dependsOn": [
-					{
-						"activity": "Get Worker Authentication Details",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"userProperties": [],
-				"typeProperties": {
-					"variableName": "WorkerSubscriptionId",
-					"value": {
-						"value": "@activity('Get Worker Authentication Details').output.firstRow.SubscriptionId",
-						"type": "Expression"
-					}
-				}
-			},
-			{
-				"name": "Set Pipeline Name",
-				"description": "Set local variable from activity output once for value reuse in downstream activities.",
-				"type": "SetVariable",
-				"dependsOn": [
-					{
-						"activity": "Get Worker Pipeline Details",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"userProperties": [],
-				"typeProperties": {
-					"variableName": "WorkerPipelineName",
-					"value": {
-						"value": "@activity('Get Worker Pipeline Details').output.firstRow.PipelineName",
-						"type": "Expression"
-					}
-				}
-			},
-			{
-				"name": "Set Data Factory Name",
-				"description": "Set local variable from activity output once for value reuse in downstream activities.",
-				"type": "SetVariable",
-				"dependsOn": [
-					{
-						"activity": "Get Worker Pipeline Details",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"userProperties": [],
-				"typeProperties": {
-					"variableName": "WorkerDataFactoryName",
-					"value": {
-						"value": "@activity('Get Worker Pipeline Details').output.firstRow.DataFactoryName",
-						"type": "Expression"
-					}
-				}
-			},
-			{
-				"name": "Set Resource Group",
-				"description": "Set local variable from activity output once for value reuse in downstream activities.",
-				"type": "SetVariable",
-				"dependsOn": [
-					{
-						"activity": "Get Worker Pipeline Details",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"userProperties": [],
-				"typeProperties": {
-					"variableName": "WorkerResourceGroup",
-					"value": {
-						"value": "@activity('Get Worker Pipeline Details').output.firstRow.ResourceGroupName",
-						"type": "Expression"
-					}
-				}
-			},
-			{
-				"name": "Validate Pipeline",
-				"description": "Query the target data factory and establish if the provided worker pipeline name is valid.",
-				"type": "AzureFunctionActivity",
-				"dependsOn": [
-					{
-						"activity": "Set Resource Group",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
-					{
-						"activity": "Set Data Factory Name",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
-					{
-						"activity": "Set Subscription Id",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
-					{
-						"activity": "Set App Secret",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
-					{
-						"activity": "Set App Id",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
-					{
-						"activity": "Set Pipeline Name",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
-					{
-						"activity": "Set Tenant Id",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					},
-					{
-						"activity": "Log Pipeline Validating",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.00:10:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": true
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"functionName": "ValidatePipeline",
-					"method": "POST",
-					"body": {
-						"value": "@concat('\n{\n\t\"tenantId\": \"',variables('WorkerTenantId'),'\",\n\t\"applicationId\": \"',variables('WorkerAppId'),'\",\n\t\"authenticationKey\": \"',variables('WorkerAppSecret'),'\",\n\t\"subscriptionId\": \"',variables('WorkerSubscriptionId'),'\",\n\t\"resourceGroup\": \"',variables('WorkerResourceGroup'),'\",\n\t\"factoryName\": \"',variables('WorkerDataFactoryName'),'\",\n\t\"pipelineName\": \"',variables('WorkerPipelineName'),'\"\n}')",
-						"type": "Expression"
-					}
-				},
-				"linkedServiceName": {
-					"referenceName": "FrameworkFunctions",
-					"type": "LinkedServiceReference"
-				}
-			},
-			{
-				"name": "Is Target Worker Validate",
-				"description": "True = the worker pipeline name is valid.\nFalse = the worker pipeline name is invalid. Raise an exception.",
-				"type": "IfCondition",
-				"dependsOn": [
-					{
-						"activity": "Validate Pipeline",
-						"dependencyConditions": [
-							"Succeeded"
-						]
-					}
-				],
-				"userProperties": [],
-				"typeProperties": {
-					"expression": {
-						"value": "@bool(activity('Validate Pipeline').output.PipelineExists)",
-						"type": "Expression"
-					},
-					"ifFalseActivities": [
-						{
-							"name": "Throw Exception - Invalid Infant",
-							"description": "Throw an exception with details about the invalid worker pipeline name.",
-							"type": "ExecutePipeline",
-							"dependsOn": [],
-							"userProperties": [],
-							"typeProperties": {
-								"pipeline": {
-									"referenceName": "Throw Exception",
-									"type": "PipelineReference"
-								},
-								"waitOnCompletion": true,
-								"parameters": {
-									"Message": {
-										"value": "@concat('Worker pipeline [',variables('WorkerPipelineName'),'] is not valid in target Data Factory [',variables('WorkerDataFactoryName'),']')",
-										"type": "Expression"
-									}
-								}
-							}
-						},
-						{
-							"name": "Update Execution With Invalid Worker",
-							"description": "Update the current execution table with an informed status for the worker pipeline that couldn't be executed.",
-							"type": "SqlServerStoredProcedure",
-							"dependsOn": [],
-							"policy": {
-								"timeout": "7.00:00:00",
-								"retry": 0,
-								"retryIntervalInSeconds": 30,
-								"secureOutput": false,
-								"secureInput": false
-							},
-							"userProperties": [],
-							"typeProperties": {
-								"storedProcedureName": "[procfwk].[SetLogActivityFailed]",
-								"storedProcedureParameters": {
-									"CallingActivity": {
-										"value": "InvalidPipelineName",
-										"type": "String"
-									},
-									"ExecutionId": {
-										"value": {
-											"value": "@pipeline().parameters.ExecutionId",
-											"type": "Expression"
-										},
-										"type": "Guid"
-									},
-									"PipelineId": {
-										"value": {
-											"value": "@pipeline().parameters.pipelineId",
-											"type": "Expression"
-										},
-										"type": "Int32"
-									},
-									"StageId": {
-										"value": {
-											"value": "@pipeline().parameters.StageId",
-											"type": "Expression"
-										},
-										"type": "Int32"
-									}
-								}
-							},
-							"linkedServiceName": {
-								"referenceName": "SupportDatabase",
-								"type": "LinkedServiceReference"
-							}
-						}
-					]
-				}
-			},
-			{
-				"name": "Log Validate Function Activity Failure",
-				"description": "Handle true failures from calling out to the Azure Function and update the current execution table accordingly so a restart can occur.",
-				"type": "SqlServerStoredProcedure",
-				"dependsOn": [
-					{
-						"activity": "Validate Pipeline",
-						"dependencyConditions": [
-							"Failed"
-						]
-					}
-				],
-				"policy": {
-					"timeout": "0.00:10:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"storedProcedureName": "[procfwk].[SetLogActivityFailed]",
-					"storedProcedureParameters": {
-						"ExecutionId": {
-							"value": {
-								"value": "@pipeline().parameters.ExecutionId",
-								"type": "Expression"
-							},
-							"type": "Guid"
-						},
-						"PipelineId": {
-							"value": {
-								"value": "@pipeline().parameters.pipelineId",
-								"type": "Expression"
-							},
-							"type": "Int32"
-						},
-						"StageId": {
-							"value": {
-								"value": "@pipeline().parameters.StageId",
-								"type": "Expression"
-							},
-							"type": "Int32"
-						},
-						"CallingActivity": {
-							"value": "ValidatePipeline",
-							"type": "String"
-						}
-					}
-				},
-				"linkedServiceName": {
-					"referenceName": "SupportDatabase",
-					"type": "LinkedServiceReference"
-				}
-			},
-			{
-				"name": "Log Pipeline Validating",
-				"description": "Sets the current pipeline with a status of validating within the current execution database table.",
-				"type": "SqlServerStoredProcedure",
-				"dependsOn": [],
-				"policy": {
-					"timeout": "0.00:10:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
-					"secureOutput": false,
-					"secureInput": false
-				},
-				"userProperties": [],
-				"typeProperties": {
-					"storedProcedureName": "[procfwk].[SetLogPipelineValidating]",
-					"storedProcedureParameters": {
-						"ExecutionId": {
-							"value": {
-								"value": "@pipeline().parameters.ExecutionId",
-								"type": "Expression"
-							},
-							"type": "Guid"
-						},
-						"PipelineId": {
-							"value": {
-								"value": "@pipeline().parameters.pipelineId",
-								"type": "Expression"
-							},
-							"type": "Int32"
-						},
-						"StageId": {
-							"value": {
-								"value": "@pipeline().parameters.StageId",
-								"type": "Expression"
-							},
-							"type": "Int32"
-						}
-					}
-				},
-				"linkedServiceName": {
-					"referenceName": "SupportDatabase",
-					"type": "LinkedServiceReference"
-				}
-			}
-		],
-		"parameters": {
-			"executionId": {
-				"type": "string"
-			},
-			"stageId": {
-				"type": "int"
-			},
-			"pipelineId": {
-				"type": "int"
-			}
-		},
-		"variables": {
-			"WorkerPipelineState": {
-				"type": "Boolean"
-			},
-			"WorkerAppId": {
-				"type": "String"
-			},
-			"WorkerAppSecret": {
-				"type": "String"
-			},
-			"WorkerRunId": {
-				"type": "String"
-			},
-			"WorkerTenantId": {
-				"type": "String"
-			},
-			"WorkerSubscriptionId": {
-				"type": "String"
-			},
-			"WorkerPipelineName": {
-				"type": "String"
-			},
-			"WorkerDataFactoryName": {
-				"type": "String"
-			},
-			"WorkerResourceGroup": {
-				"type": "String"
-			}
-		},
-		"folder": {
-			"name": "_ProcFwk"
-		},
-		"annotations": [
-			"procfwk",
-			"Infant"
-		]
-	}
+  "name": "04-Infant",
+  "properties": {
+    "description": "ADF.procfwk infant pipeline used to check when the processing pipeline called by the Child completes and passes the resulting status back to the metadata database.",
+    "activities": [
+      {
+        "name": "Execute Worker Pipeline",
+        "description": "The lowest level executor with the metadata framework to call existing processing pipelines within Data Factory. The function called will block processing and wait for an outcome.",
+        "type": "AzureFunctionActivity",
+        "dependsOn": [
+          {
+            "activity": "Log Pipeline Running",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "Get Pipeline Params",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": true
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "functionName": "ExecutePipeline",
+          "method": "POST",
+          "body": {
+            "value": "@concat('\n{\n\t\"tenantId\": \"',variables('WorkerTenantId'),'\",\n\t\"applicationId\": \"',variables('WorkerAppId'),'\",\n\t\"authenticationKey\": \"',variables('WorkerAppSecret'),'\",\n\t\"subscriptionId\": \"',variables('WorkerSubscriptionId'),'\",\n\t\"resourceGroup\": \"',variables('WorkerResourceGroup'),'\",\n\t\"factoryName\": \"',variables('WorkerDataFactoryName'),'\",\n\t\"pipelineName\": \"',variables('WorkerPipelineName'),'\"',activity('Get Pipeline Params').output.firstRow.Params,'\n}')",
+            "type": "Expression"
+          }
+        },
+        "linkedServiceName": {
+          "referenceName": "FrameworkFunctions",
+          "type": "LinkedServiceReference"
+        }
+      },
+      {
+        "name": "Get Pipeline Params",
+        "description": "Returns any parameters from metadata required for the processing pipeline being called. The output can be an empty string if no parameters are required.",
+        "type": "Lookup",
+        "dependsOn": [],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "source": {
+            "type": "AzureSqlSource",
+            "sqlReaderStoredProcedureName": "[procfwk].[GetPipelineParameters]",
+            "storedProcedureParameters": {
+              "PipelineId": {
+                "type": "Int32",
+                "value": {
+                  "value": "@pipeline().parameters.pipelineId",
+                  "type": "Expression"
+                }
+              }
+            },
+            "queryTimeout": "02:00:00",
+            "partitionOption": "None"
+          },
+          "dataset": {
+            "referenceName": "GetSetMetadata",
+            "type": "DatasetReference"
+          }
+        }
+      },
+      {
+        "name": "Log Pipeline Running",
+        "description": "Sets the current pipeline with a status of running within the current execution database table.",
+        "type": "SqlServerStoredProcedure",
+        "dependsOn": [
+          {
+            "activity": "Is Target Worker Validate",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "storedProcedureName": "[procfwk].[SetLogPipelineRunning]",
+          "storedProcedureParameters": {
+            "ExecutionId": {
+              "value": {
+                "value": "@pipeline().parameters.ExecutionId",
+                "type": "Expression"
+              },
+              "type": "Guid"
+            },
+            "PipelineId": {
+              "value": {
+                "value": "@pipeline().parameters.pipelineId",
+                "type": "Expression"
+              },
+              "type": "Int32"
+            },
+            "StageId": {
+              "value": {
+                "value": "@pipeline().parameters.StageId",
+                "type": "Expression"
+              },
+              "type": "Int32"
+            }
+          }
+        },
+        "linkedServiceName": {
+          "referenceName": "SupportDatabase",
+          "type": "LinkedServiceReference"
+        }
+      },
+      {
+        "name": "Get Worker Authentication Details",
+        "description": "Return the SPN ID and Secret for the worker pipeline being executed. Called at this level as each pipeline can have a different SPN.",
+        "type": "Lookup",
+        "dependsOn": [],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": true,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "source": {
+            "type": "AzureSqlSource",
+            "sqlReaderStoredProcedureName": "[procfwk].[GetWorkerAuthDetails]",
+            "storedProcedureParameters": {
+              "ExecutionId": {
+                "type": "Guid",
+                "value": {
+                  "value": "@pipeline().parameters.executionId",
+                  "type": "Expression"
+                }
+              },
+              "PipelineId": {
+                "type": "Int32",
+                "value": {
+                  "value": "@pipeline().parameters.pipelineId",
+                  "type": "Expression"
+                }
+              },
+              "StageId": {
+                "type": "Int32",
+                "value": {
+                  "value": "@pipeline().parameters.stageId",
+                  "type": "Expression"
+                }
+              }
+            },
+            "queryTimeout": "02:00:00",
+            "partitionOption": "None"
+          },
+          "dataset": {
+            "referenceName": "GetSetMetadata",
+            "type": "DatasetReference"
+          }
+        }
+      },
+      {
+        "name": "Log Execute Function Activity Failure",
+        "description": "Handle true failures from calling out to the Azure Function and update the current execution table accordingly so a restart can occur.",
+        "type": "SqlServerStoredProcedure",
+        "dependsOn": [
+          {
+            "activity": "Execute Worker Pipeline",
+            "dependencyConditions": [
+              "Failed"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "storedProcedureName": "[procfwk].[SetLogActivityFailed]",
+          "storedProcedureParameters": {
+            "ExecutionId": {
+              "value": {
+                "value": "@pipeline().parameters.ExecutionId",
+                "type": "Expression"
+              },
+              "type": "Guid"
+            },
+            "PipelineId": {
+              "value": {
+                "value": "@pipeline().parameters.pipelineId",
+                "type": "Expression"
+              },
+              "type": "Int32"
+            },
+            "StageId": {
+              "value": {
+                "value": "@pipeline().parameters.StageId",
+                "type": "Expression"
+              },
+              "type": "Int32"
+            },
+            "CallingActivity": {
+              "value": "ExecuteWorkerPipeline",
+              "type": "String"
+            }
+          }
+        },
+        "linkedServiceName": {
+          "referenceName": "SupportDatabase",
+          "type": "LinkedServiceReference"
+        }
+      },
+      {
+        "name": "Update Run Id",
+        "description": "Provide the actual ADF run ID back to the current execution table for long term logging and alignment between the metadata other Azure monitoring tools.",
+        "type": "SqlServerStoredProcedure",
+        "dependsOn": [
+          {
+            "activity": "Set Run Id",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "storedProcedureName": "[procfwk].[SetLogPipelineRunId]",
+          "storedProcedureParameters": {
+            "ExecutionId": {
+              "value": {
+                "value": "@pipeline().parameters.ExecutionId",
+                "type": "Expression"
+              },
+              "type": "Guid"
+            },
+            "PipelineId": {
+              "value": {
+                "value": "@pipeline().parameters.pipelineId",
+                "type": "Expression"
+              },
+              "type": "Int32"
+            },
+            "RunId": {
+              "value": {
+                "value": "@variables('WorkerRunId')",
+                "type": "Expression"
+              },
+              "type": "Guid"
+            },
+            "StageId": {
+              "value": {
+                "value": "@pipeline().parameters.StageId",
+                "type": "Expression"
+              },
+              "type": "Int32"
+            }
+          }
+        },
+        "linkedServiceName": {
+          "referenceName": "SupportDatabase",
+          "type": "LinkedServiceReference"
+        }
+      },
+      {
+        "name": "Check For Alerts",
+        "description": "Checks the properties tables and if any recipients in the database require alerts sending for the current pipeline ID.",
+        "type": "Lookup",
+        "dependsOn": [
+          {
+            "activity": "Update Run Id",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "Set Pipeline Result",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "source": {
+            "type": "AzureSqlSource",
+            "sqlReaderStoredProcedureName": "[procfwk].[CheckForEmailAlerts]",
+            "storedProcedureParameters": {
+              "PipelineId": {
+                "type": "Int32",
+                "value": {
+                  "value": "@pipeline().parameters.pipelineId",
+                  "type": "Expression"
+                }
+              }
+            },
+            "queryTimeout": "02:00:00",
+            "partitionOption": "None"
+          },
+          "dataset": {
+            "referenceName": "GetSetMetadata",
+            "type": "DatasetReference"
+          },
+          "firstRowOnly": true
+        }
+      },
+      {
+        "name": "Send Alerts",
+        "description": "True = alerts need sending.\nFalse = do nothing.",
+        "type": "IfCondition",
+        "dependsOn": [
+          {
+            "activity": "Check For Alerts",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "expression": {
+            "value": "@activity('Check For Alerts').output.firstRow.SendAlerts",
+            "type": "Expression"
+          },
+          "ifTrueActivities": [
+            {
+              "name": "Get Email Parts",
+              "description": "Return all required content from the metadata database to send an email alerting using the procfwk. The lookup returns the exact content for the function body request.",
+              "type": "Lookup",
+              "dependsOn": [],
+              "policy": {
+                "timeout": "0.00:10:00",
+                "retry": 0,
+                "retryIntervalInSeconds": 30,
+                "secureOutput": true,
+                "secureInput": false
+              },
+              "userProperties": [],
+              "typeProperties": {
+                "source": {
+                  "type": "AzureSqlSource",
+                  "sqlReaderStoredProcedureName": "[procfwk].[GetEmailAlertParts]",
+                  "storedProcedureParameters": {
+                    "PipelineId": {
+                      "type": "Int32",
+                      "value": {
+                        "value": "@pipeline().parameters.pipelineId",
+                        "type": "Expression"
+                      }
+                    }
+                  },
+                  "queryTimeout": "02:00:00",
+                  "partitionOption": "None"
+                },
+                "dataset": {
+                  "referenceName": "GetSetMetadata",
+                  "type": "DatasetReference"
+                },
+                "firstRowOnly": true
+              }
+            },
+            {
+              "name": "Send Email",
+              "type": "ExecutePipeline",
+              "dependsOn": [
+                {
+                  "activity": "Get Email Parts",
+                  "dependencyConditions": [
+                    "Succeeded"
+                  ]
+                }
+              ],
+              "userProperties": [],
+              "typeProperties": {
+                "pipeline": {
+                  "referenceName": "Email Sender",
+                  "type": "PipelineReference"
+                },
+                "waitOnCompletion": true,
+                "parameters": {
+                  "Recipients": {
+                    "value": "@activity('Get Email Parts').output.firstRow.emailRecipients",
+                    "type": "Expression"
+                  },
+                  "CcRecipients": {
+                    "value": "@activity('Get Email Parts').output.firstRow.emailCcRecipients",
+                    "type": "Expression"
+                  },
+                  "BccRecipients": {
+                    "value": "@activity('Get Email Parts').output.firstRow.emailBccRecipients",
+                    "type": "Expression"
+                  },
+                  "Subject": {
+                    "value": "@activity('Get Email Parts').output.firstRow.emailSubject",
+                    "type": "Expression"
+                  },
+                  "Body": {
+                    "value": "@activity('Get Email Parts').output.firstRow.emailBody",
+                    "type": "Expression"
+                  },
+                  "Importance": {
+                    "value": "@activity('Get Email Parts').output.firstRow.emailImportance",
+                    "type": "Expression"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "Wait Until Pipeline Completes",
+        "description": "Loops until the Worker pipeline called completes.\n\nSimple status:\n- Running = new iteration.\n- Done = break.",
+        "type": "Until",
+        "dependsOn": [
+          {
+            "activity": "Get Wait Duration",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "Execute Worker Pipeline",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "Set Run Id",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "expression": {
+            "value": "@variables('WorkerPipelineState')",
+            "type": "Expression"
+          },
+          "activities": [
+            {
+              "name": "Get Worker Pipeline Status",
+              "description": "Checks the status of a given processing pipeline and provides the value for the downstream framework activities to act upon.",
+              "type": "AzureFunctionActivity",
+              "dependsOn": [],
+              "policy": {
+                "timeout": "0.00:10:00",
+                "retry": 0,
+                "retryIntervalInSeconds": 30,
+                "secureOutput": false,
+                "secureInput": true
+              },
+              "userProperties": [],
+              "typeProperties": {
+                "functionName": "CheckPipelineStatus",
+                "method": "POST",
+                "body": {
+                  "value": "@concat('\n{\n    \"tenantId\": \"',variables('WorkerTenantId'),'\",\n    \"applicationId\": \"',variables('WorkerAppId'),'\",\n    \"authenticationKey\": \"',variables('WorkerAppSecret'),'\",\n    \"subscriptionId\": \"',variables('WorkerSubscriptionId'),'\",\n    \"resourceGroup\": \"',variables('WorkerResourceGroup'),'\",\n    \"factoryName\": \"',variables('WorkerDataFactoryName'),'\",\n    \"pipelineName\": \"',variables('WorkerPipelineName'),'\",\n    \"runId\": \"',variables('WorkerRunId'),'\"\n}')",
+                  "type": "Expression"
+                }
+              },
+              "linkedServiceName": {
+                "referenceName": "FrameworkFunctions",
+                "type": "LinkedServiceReference"
+              }
+            },
+            {
+              "name": "Wait If Running",
+              "description": "True = Do nothing.\nFalse = Wait, before the next iteration.",
+              "type": "IfCondition",
+              "dependsOn": [
+                {
+                  "activity": "Set Worker State",
+                  "dependencyConditions": [
+                    "Succeeded"
+                  ]
+                }
+              ],
+              "userProperties": [],
+              "typeProperties": {
+                "expression": {
+                  "value": "@variables('WorkerPipelineState')",
+                  "type": "Expression"
+                },
+                "ifFalseActivities": [
+                  {
+                    "name": "Wait for Pipeline",
+                    "description": "The processing pipeline is still running so Wait before checking its status again.",
+                    "type": "Wait",
+                    "dependsOn": [],
+                    "userProperties": [],
+                    "typeProperties": {
+                      "waitTimeInSeconds": {
+                        "value": "@activity('Get Wait Duration').output.firstRow.PropertyValue",
+                        "type": "Expression"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Set Last Check DateTime",
+              "description": "Update the current execution table with a date time from when the Worker pipeline status was last checked as part of the Until iterations.",
+              "type": "SqlServerStoredProcedure",
+              "dependsOn": [
+                {
+                  "activity": "Get Worker Pipeline Status",
+                  "dependencyConditions": [
+                    "Succeeded"
+                  ]
+                }
+              ],
+              "policy": {
+                "timeout": "0.00:10:00",
+                "retry": 0,
+                "retryIntervalInSeconds": 30,
+                "secureOutput": false,
+                "secureInput": false
+              },
+              "userProperties": [],
+              "typeProperties": {
+                "storedProcedureName": "[procfwk].[SetLogPipelineLastStatusCheck]",
+                "storedProcedureParameters": {
+                  "ExecutionId": {
+                    "value": {
+                      "value": "@pipeline().parameters.executionId",
+                      "type": "Expression"
+                    },
+                    "type": "Guid"
+                  },
+                  "PipelineId": {
+                    "value": {
+                      "value": "@pipeline().parameters.pipelineId",
+                      "type": "Expression"
+                    },
+                    "type": "Int32"
+                  },
+                  "StageId": {
+                    "value": {
+                      "value": "@pipeline().parameters.stageId",
+                      "type": "Expression"
+                    },
+                    "type": "Int32"
+                  }
+                }
+              },
+              "linkedServiceName": {
+                "referenceName": "SupportDatabase",
+                "type": "LinkedServiceReference"
+              }
+            },
+            {
+              "name": "Log Check Function Activity Failure",
+              "description": "Report to the current execution table that the framework pipeline activity has failed. This failure is outside of the scope of the framework and is probably related to a wider platform problem.",
+              "type": "SqlServerStoredProcedure",
+              "dependsOn": [
+                {
+                  "activity": "Get Worker Pipeline Status",
+                  "dependencyConditions": [
+                    "Failed"
+                  ]
+                }
+              ],
+              "policy": {
+                "timeout": "0.00:10:00",
+                "retry": 0,
+                "retryIntervalInSeconds": 30,
+                "secureOutput": false,
+                "secureInput": false
+              },
+              "userProperties": [],
+              "typeProperties": {
+                "storedProcedureName": "[procfwk].[SetLogActivityFailed]",
+                "storedProcedureParameters": {
+                  "CallingActivity": {
+                    "value": "GetWorkerPipelineStatus",
+                    "type": "String"
+                  },
+                  "ExecutionId": {
+                    "value": {
+                      "value": "@pipeline().parameters.executionId",
+                      "type": "Expression"
+                    },
+                    "type": "Guid"
+                  },
+                  "PipelineId": {
+                    "value": {
+                      "value": "@pipeline().parameters.pipelineId",
+                      "type": "Expression"
+                    },
+                    "type": "Int32"
+                  },
+                  "StageId": {
+                    "value": {
+                      "value": "@pipeline().parameters.stageId",
+                      "type": "Expression"
+                    },
+                    "type": "Int32"
+                  }
+                }
+              },
+              "linkedServiceName": {
+                "referenceName": "SupportDatabase",
+                "type": "LinkedServiceReference"
+              }
+            },
+            {
+              "name": "Set Worker State",
+              "description": "Set the bool state of the Worker pipeline to be used by the Until and If expressions. True = Complete, False = Running.",
+              "type": "SetVariable",
+              "dependsOn": [
+                {
+                  "activity": "Get Worker Pipeline Status",
+                  "dependencyConditions": [
+                    "Succeeded"
+                  ]
+                }
+              ],
+              "userProperties": [],
+              "typeProperties": {
+                "variableName": "WorkerPipelineState",
+                "value": {
+                  "value": "@equals('Done',activity('Get Worker Pipeline Status').output.SimpleStatus)",
+                  "type": "Expression"
+                }
+              }
+            }
+          ],
+          "timeout": "0.00:10:00"
+        }
+      },
+      {
+        "name": "Set Pipeline Result",
+        "description": "Receives the outcome from the function execution for a given processing pipeline and updates the current execution table with different pipelines status values depending on the result (case).",
+        "type": "Switch",
+        "dependsOn": [
+          {
+            "activity": "Wait Until Pipeline Completes",
+            "dependencyConditions": [
+              "Completed"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "on": {
+            "value": "@activity('Get Worker Pipeline Status').output.Status",
+            "type": "Expression"
+          },
+          "cases": [
+            {
+              "value": "Succeeded",
+              "activities": [
+                {
+                  "name": "Pipeline Status Succeeded",
+                  "description": "Updates the current execution table with a pipeline status of success if the function outcome is succeeded.",
+                  "type": "SqlServerStoredProcedure",
+                  "dependsOn": [],
+                  "policy": {
+                    "timeout": "0.00:10:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                  },
+                  "userProperties": [],
+                  "typeProperties": {
+                    "storedProcedureName": "[procfwk].[SetLogPipelineSuccess]",
+                    "storedProcedureParameters": {
+                      "ExecutionId": {
+                        "value": {
+                          "value": "@pipeline().parameters.executionId",
+                          "type": "Expression"
+                        },
+                        "type": "Guid"
+                      },
+                      "PipelineId": {
+                        "value": {
+                          "value": "@pipeline().parameters.pipelineId",
+                          "type": "Expression"
+                        },
+                        "type": "Int32"
+                      },
+                      "StageId": {
+                        "value": {
+                          "value": "@pipeline().parameters.stageId",
+                          "type": "Expression"
+                        },
+                        "type": "Int32"
+                      }
+                    }
+                  },
+                  "linkedServiceName": {
+                    "referenceName": "SupportDatabase",
+                    "type": "LinkedServiceReference"
+                  }
+                }
+              ]
+            },
+            {
+              "value": "Failed",
+              "activities": [
+                {
+                  "name": "Pipeline Status Failed",
+                  "description": "Updates the current execution table with a pipeline status of failed if the function outcome is failed. Also blocks pipelines in the downstream execution stage.",
+                  "type": "SqlServerStoredProcedure",
+                  "dependsOn": [],
+                  "policy": {
+                    "timeout": "0.00:10:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                  },
+                  "userProperties": [],
+                  "typeProperties": {
+                    "storedProcedureName": "[procfwk].[SetLogPipelineFailed]",
+                    "storedProcedureParameters": {
+                      "ExecutionId": {
+                        "value": {
+                          "value": "@pipeline().parameters.executionId",
+                          "type": "Expression"
+                        },
+                        "type": "Guid"
+                      },
+                      "PipelineId": {
+                        "value": {
+                          "value": "@pipeline().parameters.pipelineId",
+                          "type": "Expression"
+                        },
+                        "type": "Int32"
+                      },
+                      "RunId": {
+                        "value": {
+                          "value": "@variables('WorkerRunId')",
+                          "type": "Expression"
+                        },
+                        "type": "Guid"
+                      },
+                      "StageId": {
+                        "value": {
+                          "value": "@pipeline().parameters.stageId",
+                          "type": "Expression"
+                        },
+                        "type": "Int32"
+                      }
+                    }
+                  },
+                  "linkedServiceName": {
+                    "referenceName": "SupportDatabase",
+                    "type": "LinkedServiceReference"
+                  }
+                },
+                {
+                  "name": "Get Worker Pipeline Error Details",
+                  "description": "Get the activity error details for the run ID of the worker pipeline called. Returns an array of all errors.",
+                  "type": "AzureFunctionActivity",
+                  "dependsOn": [],
+                  "policy": {
+                    "timeout": "0.00:10:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": true
+                  },
+                  "userProperties": [],
+                  "typeProperties": {
+                    "functionName": "GetActivityErrors",
+                    "method": "POST",
+                    "body": {
+                      "value": "@concat('\n{\n    \"tenantId\": \"',variables('WorkerTenantId'),'\",\n    \"applicationId\": \"',variables('WorkerAppId'),'\",\n    \"authenticationKey\": \"',variables('WorkerAppSecret'),'\",\n    \"subscriptionId\": \"',variables('WorkerSubscriptionId'),'\",\n    \"resourceGroup\": \"',variables('WorkerResourceGroup'),'\",\n    \"factoryName\": \"',variables('WorkerDataFactoryName'),'\",\n    \"pipelineName\": \"',variables('WorkerPipelineName'),'\",\n    \"runId\": \"',variables('WorkerRunId'),'\"\n}')",
+                      "type": "Expression"
+                    }
+                  },
+                  "linkedServiceName": {
+                    "referenceName": "FrameworkFunctions",
+                    "type": "LinkedServiceReference"
+                  }
+                },
+                {
+                  "name": "Log Error Details",
+                  "description": "Parses pipeline error details and persists them to the metadata database error log table.",
+                  "type": "SqlServerStoredProcedure",
+                  "dependsOn": [
+                    {
+                      "activity": "Get Worker Pipeline Error Details",
+                      "dependencyConditions": [
+                        "Succeeded"
+                      ]
+                    }
+                  ],
+                  "policy": {
+                    "timeout": "0.00:10:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                  },
+                  "userProperties": [],
+                  "typeProperties": {
+                    "storedProcedureName": "[procfwk].[SetErrorLogDetails]",
+                    "storedProcedureParameters": {
+                      "JsonErrorDetails": {
+                        "value": {
+                          "value": "@string(activity('Get Worker Pipeline Error Details').output)",
+                          "type": "Expression"
+                        },
+                        "type": "String"
+                      },
+                      "LocalExecutionId": {
+                        "value": {
+                          "value": "@pipeline().parameters.executionId",
+                          "type": "Expression"
+                        },
+                        "type": "Guid"
+                      }
+                    }
+                  },
+                  "linkedServiceName": {
+                    "referenceName": "SupportDatabase",
+                    "type": "LinkedServiceReference"
+                  }
+                }
+              ]
+            },
+            {
+              "value": "Cancelled",
+              "activities": [
+                {
+                  "name": "Pipeline Status Cancelled",
+                  "description": "Updates the current execution table with a pipeline status of cancelled if the function outcome is cancelled.",
+                  "type": "SqlServerStoredProcedure",
+                  "dependsOn": [],
+                  "policy": {
+                    "timeout": "0.00:10:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                  },
+                  "userProperties": [],
+                  "typeProperties": {
+                    "storedProcedureName": "[procfwk].[SetLogPipelineCancelled]",
+                    "storedProcedureParameters": {
+                      "ExecutionId": {
+                        "value": {
+                          "value": "@pipeline().parameters.executionId",
+                          "type": "Expression"
+                        },
+                        "type": "Guid"
+                      },
+                      "PipelineId": {
+                        "value": {
+                          "value": "@pipeline().parameters.pipelineId",
+                          "type": "Expression"
+                        },
+                        "type": "Int32"
+                      },
+                      "StageId": {
+                        "value": {
+                          "value": "@pipeline().parameters.stageId",
+                          "type": "Expression"
+                        },
+                        "type": "Int32"
+                      }
+                    }
+                  },
+                  "linkedServiceName": {
+                    "referenceName": "SupportDatabase",
+                    "type": "LinkedServiceReference"
+                  }
+                }
+              ]
+            }
+          ],
+          "defaultActivities": [
+            {
+              "name": "Pipeline Status Unknown",
+              "description": "Updates the current execution table with a pipeline status of unknown if the function returns an unexpected outcome.",
+              "type": "SqlServerStoredProcedure",
+              "dependsOn": [],
+              "policy": {
+                "timeout": "0.00:10:00",
+                "retry": 0,
+                "retryIntervalInSeconds": 30,
+                "secureOutput": false,
+                "secureInput": false
+              },
+              "userProperties": [],
+              "typeProperties": {
+                "storedProcedureName": "[procfwk].[SetLogPipelineUnknown]",
+                "storedProcedureParameters": {
+                  "ExecutionId": {
+                    "value": {
+                      "value": "@pipeline().parameters.executionId",
+                      "type": "Expression"
+                    },
+                    "type": "Guid"
+                  },
+                  "PipelineId": {
+                    "value": {
+                      "value": "@pipeline().parameters.pipelineId",
+                      "type": "Expression"
+                    },
+                    "type": "Int32"
+                  },
+                  "StageId": {
+                    "value": {
+                      "value": "@pipeline().parameters.stageId",
+                      "type": "Expression"
+                    },
+                    "type": "Int32"
+                  }
+                }
+              },
+              "linkedServiceName": {
+                "referenceName": "SupportDatabase",
+                "type": "LinkedServiceReference"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "Get Wait Duration",
+        "description": "Return wait duration in seconds from database properties table to be used during each Until iteration when the Worker pipeline is still running.",
+        "type": "Lookup",
+        "dependsOn": [],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "source": {
+            "type": "AzureSqlSource",
+            "sqlReaderStoredProcedureName": "[procfwk].[GetPropertyValue]",
+            "storedProcedureParameters": {
+              "PropertyName": {
+                "type": "String",
+                "value": "PipelineStatusCheckDuration"
+              }
+            },
+            "queryTimeout": "02:00:00",
+            "partitionOption": "None"
+          },
+          "dataset": {
+            "referenceName": "GetSetMetadata",
+            "type": "DatasetReference"
+          }
+        }
+      },
+      {
+        "name": "Set App Id",
+        "description": "Set local variable from activity output once for value reuse in downstream activities.",
+        "type": "SetVariable",
+        "dependsOn": [
+          {
+            "activity": "Get Worker Authentication Details",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "variableName": "WorkerAppId",
+          "value": {
+            "value": "@activity('Get Worker Authentication Details').output.firstRow.AppId",
+            "type": "Expression"
+          }
+        }
+      },
+      {
+        "name": "Set App Secret",
+        "description": "Set local variable from activity output once for value reuse in downstream activities.",
+        "type": "SetVariable",
+        "dependsOn": [
+          {
+            "activity": "Get Worker Authentication Details",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "variableName": "WorkerAppSecret",
+          "value": {
+            "value": "@activity('Get Worker Authentication Details').output.firstRow.AppSecret",
+            "type": "Expression"
+          }
+        }
+      },
+      {
+        "name": "Set Run Id",
+        "description": "Set local variable from activity output once for value reuse in downstream activities.",
+        "type": "SetVariable",
+        "dependsOn": [
+          {
+            "activity": "Execute Worker Pipeline",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "variableName": "WorkerRunId",
+          "value": {
+            "value": "@activity('Execute Worker Pipeline').output.RunId",
+            "type": "Expression"
+          }
+        }
+      },
+      {
+        "name": "Get Worker Pipeline Details",
+        "description": "Return none sensitive worker pipeline information for metadata database. Including target data factory, pipeline name and resource group.",
+        "type": "Lookup",
+        "dependsOn": [],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": true,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "source": {
+            "type": "AzureSqlSource",
+            "sqlReaderStoredProcedureName": "[procfwk].[GetWorkerPipelineDetails]",
+            "storedProcedureParameters": {
+              "ExecutionId": {
+                "type": "Guid",
+                "value": {
+                  "value": "@pipeline().parameters.ExecutionId",
+                  "type": "Expression"
+                }
+              },
+              "PipelineId": {
+                "type": "Int32",
+                "value": {
+                  "value": "@pipeline().parameters.pipelineId",
+                  "type": "Expression"
+                }
+              },
+              "StageId": {
+                "type": "Int32",
+                "value": {
+                  "value": "@pipeline().parameters.stageId",
+                  "type": "Expression"
+                }
+              }
+            },
+            "queryTimeout": "02:00:00",
+            "partitionOption": "None"
+          },
+          "dataset": {
+            "referenceName": "GetSetMetadata",
+            "type": "DatasetReference"
+          }
+        }
+      },
+      {
+        "name": "Set Tenant Id",
+        "description": "Set local variable from activity output once for value reuse in downstream activities.",
+        "type": "SetVariable",
+        "dependsOn": [
+          {
+            "activity": "Get Worker Authentication Details",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "variableName": "WorkerTenantId",
+          "value": {
+            "value": "@activity('Get Worker Authentication Details').output.firstRow.TenantId",
+            "type": "Expression"
+          }
+        }
+      },
+      {
+        "name": "Set Subscription Id",
+        "description": "Set local variable from activity output once for value reuse in downstream activities.",
+        "type": "SetVariable",
+        "dependsOn": [
+          {
+            "activity": "Get Worker Authentication Details",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "variableName": "WorkerSubscriptionId",
+          "value": {
+            "value": "@activity('Get Worker Authentication Details').output.firstRow.SubscriptionId",
+            "type": "Expression"
+          }
+        }
+      },
+      {
+        "name": "Set Pipeline Name",
+        "description": "Set local variable from activity output once for value reuse in downstream activities.",
+        "type": "SetVariable",
+        "dependsOn": [
+          {
+            "activity": "Get Worker Pipeline Details",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "variableName": "WorkerPipelineName",
+          "value": {
+            "value": "@activity('Get Worker Pipeline Details').output.firstRow.PipelineName",
+            "type": "Expression"
+          }
+        }
+      },
+      {
+        "name": "Set Data Factory Name",
+        "description": "Set local variable from activity output once for value reuse in downstream activities.",
+        "type": "SetVariable",
+        "dependsOn": [
+          {
+            "activity": "Get Worker Pipeline Details",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "variableName": "WorkerDataFactoryName",
+          "value": {
+            "value": "@activity('Get Worker Pipeline Details').output.firstRow.DataFactoryName",
+            "type": "Expression"
+          }
+        }
+      },
+      {
+        "name": "Set Resource Group",
+        "description": "Set local variable from activity output once for value reuse in downstream activities.",
+        "type": "SetVariable",
+        "dependsOn": [
+          {
+            "activity": "Get Worker Pipeline Details",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "variableName": "WorkerResourceGroup",
+          "value": {
+            "value": "@activity('Get Worker Pipeline Details').output.firstRow.ResourceGroupName",
+            "type": "Expression"
+          }
+        }
+      },
+      {
+        "name": "Validate Pipeline",
+        "description": "Query the target data factory and establish if the provided worker pipeline name is valid.",
+        "type": "AzureFunctionActivity",
+        "dependsOn": [
+          {
+            "activity": "Set Resource Group",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "Set Data Factory Name",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "Set Subscription Id",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "Set App Secret",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "Set App Id",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "Set Pipeline Name",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "Set Tenant Id",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          },
+          {
+            "activity": "Log Pipeline Validating",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": true
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "functionName": "ValidatePipeline",
+          "method": "POST",
+          "body": {
+            "value": "@concat('\n{\n\t\"tenantId\": \"',variables('WorkerTenantId'),'\",\n\t\"applicationId\": \"',variables('WorkerAppId'),'\",\n\t\"authenticationKey\": \"',variables('WorkerAppSecret'),'\",\n\t\"subscriptionId\": \"',variables('WorkerSubscriptionId'),'\",\n\t\"resourceGroup\": \"',variables('WorkerResourceGroup'),'\",\n\t\"factoryName\": \"',variables('WorkerDataFactoryName'),'\",\n\t\"pipelineName\": \"',variables('WorkerPipelineName'),'\"\n}')",
+            "type": "Expression"
+          }
+        },
+        "linkedServiceName": {
+          "referenceName": "FrameworkFunctions",
+          "type": "LinkedServiceReference"
+        }
+      },
+      {
+        "name": "Is Target Worker Validate",
+        "description": "True = the worker pipeline name is valid.\nFalse = the worker pipeline name is invalid. Raise an exception.",
+        "type": "IfCondition",
+        "dependsOn": [
+          {
+            "activity": "Validate Pipeline",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "expression": {
+            "value": "@bool(activity('Validate Pipeline').output.PipelineExists)",
+            "type": "Expression"
+          },
+          "ifFalseActivities": [
+            {
+              "name": "Throw Exception - Invalid Infant",
+              "description": "Throw an exception with details about the invalid worker pipeline name.",
+              "type": "ExecutePipeline",
+              "dependsOn": [],
+              "userProperties": [],
+              "typeProperties": {
+                "pipeline": {
+                  "referenceName": "Throw Exception",
+                  "type": "PipelineReference"
+                },
+                "waitOnCompletion": true,
+                "parameters": {
+                  "Message": {
+                    "value": "@concat('Worker pipeline [',variables('WorkerPipelineName'),'] is not valid in target Data Factory [',variables('WorkerDataFactoryName'),']')",
+                    "type": "Expression"
+                  }
+                }
+              }
+            },
+            {
+              "name": "Update Execution With Invalid Worker",
+              "description": "Update the current execution table with an informed status for the worker pipeline that couldn't be executed.",
+              "type": "SqlServerStoredProcedure",
+              "dependsOn": [],
+              "policy": {
+                "timeout": "7.00:00:00",
+                "retry": 0,
+                "retryIntervalInSeconds": 30,
+                "secureOutput": false,
+                "secureInput": false
+              },
+              "userProperties": [],
+              "typeProperties": {
+                "storedProcedureName": "[procfwk].[SetLogActivityFailed]",
+                "storedProcedureParameters": {
+                  "CallingActivity": {
+                    "value": "InvalidPipelineName",
+                    "type": "String"
+                  },
+                  "ExecutionId": {
+                    "value": {
+                      "value": "@pipeline().parameters.ExecutionId",
+                      "type": "Expression"
+                    },
+                    "type": "Guid"
+                  },
+                  "PipelineId": {
+                    "value": {
+                      "value": "@pipeline().parameters.pipelineId",
+                      "type": "Expression"
+                    },
+                    "type": "Int32"
+                  },
+                  "StageId": {
+                    "value": {
+                      "value": "@pipeline().parameters.StageId",
+                      "type": "Expression"
+                    },
+                    "type": "Int32"
+                  }
+                }
+              },
+              "linkedServiceName": {
+                "referenceName": "SupportDatabase",
+                "type": "LinkedServiceReference"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "Log Validate Function Activity Failure",
+        "description": "Handle true failures from calling out to the Azure Function and update the current execution table accordingly so a restart can occur.",
+        "type": "SqlServerStoredProcedure",
+        "dependsOn": [
+          {
+            "activity": "Validate Pipeline",
+            "dependencyConditions": [
+              "Failed"
+            ]
+          }
+        ],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "storedProcedureName": "[procfwk].[SetLogActivityFailed]",
+          "storedProcedureParameters": {
+            "ExecutionId": {
+              "value": {
+                "value": "@pipeline().parameters.ExecutionId",
+                "type": "Expression"
+              },
+              "type": "Guid"
+            },
+            "PipelineId": {
+              "value": {
+                "value": "@pipeline().parameters.pipelineId",
+                "type": "Expression"
+              },
+              "type": "Int32"
+            },
+            "StageId": {
+              "value": {
+                "value": "@pipeline().parameters.StageId",
+                "type": "Expression"
+              },
+              "type": "Int32"
+            },
+            "CallingActivity": {
+              "value": "ValidatePipeline",
+              "type": "String"
+            }
+          }
+        },
+        "linkedServiceName": {
+          "referenceName": "SupportDatabase",
+          "type": "LinkedServiceReference"
+        }
+      },
+      {
+        "name": "Log Pipeline Validating",
+        "description": "Sets the current pipeline with a status of validating within the current execution database table.",
+        "type": "SqlServerStoredProcedure",
+        "dependsOn": [],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "storedProcedureName": "[procfwk].[SetLogPipelineValidating]",
+          "storedProcedureParameters": {
+            "ExecutionId": {
+              "value": {
+                "value": "@pipeline().parameters.ExecutionId",
+                "type": "Expression"
+              },
+              "type": "Guid"
+            },
+            "PipelineId": {
+              "value": {
+                "value": "@pipeline().parameters.pipelineId",
+                "type": "Expression"
+              },
+              "type": "Int32"
+            },
+            "StageId": {
+              "value": {
+                "value": "@pipeline().parameters.StageId",
+                "type": "Expression"
+              },
+              "type": "Int32"
+            }
+          }
+        },
+        "linkedServiceName": {
+          "referenceName": "SupportDatabase",
+          "type": "LinkedServiceReference"
+        }
+      }
+    ],
+    "parameters": {
+      "executionId": {
+        "type": "string"
+      },
+      "stageId": {
+        "type": "int"
+      },
+      "pipelineId": {
+        "type": "int"
+      }
+    },
+    "variables": {
+      "WorkerPipelineState": {
+        "type": "Boolean"
+      },
+      "WorkerAppId": {
+        "type": "String"
+      },
+      "WorkerAppSecret": {
+        "type": "String"
+      },
+      "WorkerRunId": {
+        "type": "String"
+      },
+      "WorkerTenantId": {
+        "type": "String"
+      },
+      "WorkerSubscriptionId": {
+        "type": "String"
+      },
+      "WorkerPipelineName": {
+        "type": "String"
+      },
+      "WorkerDataFactoryName": {
+        "type": "String"
+      },
+      "WorkerResourceGroup": {
+        "type": "String"
+      }
+    },
+    "folder": {
+      "name": "_ProcFwk"
+    },
+    "annotations": [
+      "procfwk",
+      "Infant"
+    ]
+  }
 }

--- a/DeploymentTools/DataFactory/ProcFwkComponents.json
+++ b/DeploymentTools/DataFactory/ProcFwkComponents.json
@@ -13,7 +13,8 @@
     "/pipeline/02-Parent.json",
     "/pipeline/01-Grandparent.json",
     "/pipeline/Throw Exception.json",
-    "/pipeline/Check For Running Pipeline.json"
+    "/pipeline/Check For Running Pipeline.json",
+    "/pipeline/Email Sender.json"
   ],
   "triggers": [
     "/trigger/FunctionalTestingTrigger.json"

--- a/Email Sender.json
+++ b/Email Sender.json
@@ -1,0 +1,61 @@
+{
+  "name": "Email Sender",
+  "properties": {
+    "description": "Provide a simple abstract over the send email function with request body item exposed as pipeline parameters.",
+    "activities": [
+      {
+        "name": "Send Email",
+        "description": "Use an Azure Function to perform an SMTP client email send operation.",
+        "type": "AzureFunctionActivity",
+        "dependsOn": [],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "functionName": "SendEmail",
+          "method": "POST",
+          "body": {
+            "value": "{\n\"emailRecipients\": \"@{pipeline().parameters.Recipients}\",\n\"emailCcRecipients\": \"@{pipeline().parameters.CcRecipients}\",\n\"emailBccRecipients\": \"@{pipeline().parameters.BccRecipients}\",\n\"emailSubject\": \"@{pipeline().parameters.Subject}\",\n\"emailBody\": \"@{pipeline().parameters.Body}\",\n\"emailImportance\": \"@{pipeline().parameters.Importance}\"\n}",
+            "type": "Expression"
+          }
+        },
+        "linkedServiceName": {
+          "referenceName": "FrameworkFunctions",
+          "type": "LinkedServiceReference"
+        }
+      }
+    ],
+    "parameters": {
+      "Recipients": {
+        "type": "string"
+      },
+      "CcRecipients": {
+        "type": "string"
+      },
+      "BccRecipients": {
+        "type": "string"
+      },
+      "Subject": {
+        "type": "string"
+      },
+      "Body": {
+        "type": "string"
+      },
+      "Importance": {
+        "type": "string"
+      }
+    },
+    "folder": {
+      "name": "_ProcFwk/_ProcFwkUtils"
+    },
+    "annotations": [
+      "procfwk",
+      "Utils"
+    ]
+  }
+}

--- a/Intentional Error.json
+++ b/Intentional Error.json
@@ -1,0 +1,88 @@
+{
+  "name": "Intentional Error",
+  "properties": {
+    "description": "Used just so the ADF.procfwk has something to call during development.",
+    "activities": [
+      {
+        "name": "Wait1",
+        "description": "Framework development worker simulator.",
+        "type": "Wait",
+        "dependsOn": [],
+        "userProperties": [],
+        "typeProperties": {
+          "waitTimeInSeconds": {
+            "value": "@pipeline().parameters.WaitTime",
+            "type": "Expression"
+          }
+        }
+      },
+      {
+        "name": "Raise Errors or Not",
+        "description": "Framework development worker simulator.",
+        "type": "IfCondition",
+        "dependsOn": [
+          {
+            "activity": "Wait1",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ],
+        "userProperties": [],
+        "typeProperties": {
+          "expression": {
+            "value": "@equals(pipeline().parameters.RaiseErrors,'true')",
+            "type": "Expression"
+          },
+          "ifTrueActivities": [
+            {
+              "name": "Call Fail Procedure",
+              "type": "SqlServerStoredProcedure",
+              "dependsOn": [],
+              "policy": {
+                "timeout": "0.00:10:00",
+                "retry": 0,
+                "retryIntervalInSeconds": 0,
+                "secureOutput": false,
+                "secureInput": false
+              },
+              "userProperties": [],
+              "typeProperties": {
+                "storedProcedureName": "[dbo].[FailProcedure]",
+                "storedProcedureParameters": {
+                  "RaiseError": {
+                    "value": {
+                      "value": "@pipeline().parameters.RaiseErrors",
+                      "type": "Expression"
+                    },
+                    "type": "String"
+                  }
+                }
+              },
+              "linkedServiceName": {
+                "referenceName": "SupportDatabase",
+                "type": "LinkedServiceReference"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "parameters": {
+      "RaiseErrors": {
+        "type": "string",
+        "defaultValue": "false"
+      },
+      "WaitTime": {
+        "type": "int",
+        "defaultValue": 5
+      }
+    },
+    "folder": {
+      "name": "_Workers"
+    },
+    "annotations": [
+      "Worker"
+    ]
+  }
+}

--- a/MetadataDB/procfwk/Stored Procedures/CheckForEmailAlerts.sql
+++ b/MetadataDB/procfwk/Stored Procedures/CheckForEmailAlerts.sql
@@ -28,7 +28,10 @@ BEGIN
 				INNER JOIN procfwk.Recipients AS r
 					ON r.RecipientId = pal.RecipientId
 				WHERE ce.PipelineId = @PipelineId
-					  AND ao.BitValue & pal.OutcomesBitValue > 0
+					  AND (
+						ao.BitValue & pal.OutcomesBitValue <> 0
+						OR pal.OutcomesBitValue & 1 <> 0 --all
+						)
 					  AND pal.[Enabled] = 1
 					  AND r.[Enabled] = 1
 				)

--- a/ProcessingFramework.sln
+++ b/ProcessingFramework.sln
@@ -120,6 +120,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FactoryTesting", "FactoryTe
 EndProject
 Project("{00D1A9C2-B5F0-4AF3-8072-F6C62B433612}") = "MetadataDBTests", "MetadataDBTests\MetadataDBTests.sqlproj", "{32D54B90-932D-44A3-911D-007C4B90BC55}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_ProcFwkUtils", "_ProcFwkUtils", "{B0D1372F-D609-471C-BD62-AF81A6FA74FD}"
+	ProjectSection(SolutionItems) = preProject
+		Check For Running Pipeline.json = Check For Running Pipeline.json
+		Email Sender.json = Email Sender.json
+		Intentional Error.json = Intentional Error.json
+		Throw Exception.json = Throw Exception.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -165,6 +173,7 @@ Global
 		{EBC230DF-D45D-43E4-A74E-32ADA3DDAE7A} = {5A56A63A-351D-467D-A2DA-FDB3C9CBD252}
 		{20313ECA-118E-408D-BB42-8094A7A9CD20} = {CC7B607B-8C84-4E07-A6C8-326923752F92}
 		{463330CD-189F-42B4-984A-8D3C1385645B} = {CC7B607B-8C84-4E07-A6C8-326923752F92}
+		{B0D1372F-D609-471C-BD62-AF81A6FA74FD} = {17586826-8BE9-4622-B12E-1683F2A20352}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {170F5302-BB9C-4569-8F43-D859C7678EF0}

--- a/Throw Exception.json
+++ b/Throw Exception.json
@@ -1,0 +1,50 @@
+{
+  "name": "Throw Exception",
+  "properties": {
+    "description": "Provide a simple way of throwing an exception within Data Factory using TSQL error handling.",
+    "activities": [
+      {
+        "name": "Raise Error",
+        "description": "Using a SQL database to raise an error/exception but wrapped up as a data factory pipeline. Error message information exposed as a pipeline parameter.",
+        "type": "Lookup",
+        "dependsOn": [],
+        "policy": {
+          "timeout": "0.00:10:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "userProperties": [],
+        "typeProperties": {
+          "source": {
+            "type": "AzureSqlSource",
+            "sqlReaderQuery": {
+              "value": "RAISERROR('@{pipeline().parameters.Message}',16,1);",
+              "type": "Expression"
+            },
+            "queryTimeout": "02:00:00",
+            "partitionOption": "None"
+          },
+          "dataset": {
+            "referenceName": "GetSetMetadata",
+            "type": "DatasetReference"
+          },
+          "firstRowOnly": false
+        }
+      }
+    ],
+    "parameters": {
+      "Message": {
+        "type": "string"
+      }
+    },
+    "folder": {
+      "name": "_ProcFwk/_ProcFwkUtils"
+    },
+    "annotations": [
+      "procfwk",
+      "Utils"
+    ]
+  }
+}


### PR DESCRIPTION
Made the following changes for issue #87 

- Added the 4 _'ProcFwkUtils'_ pipelines to the solution
- Changed pipeline _'04-Infant'_ to call the new pipeline _'Email Sender'_ instead of calling the Azure Function directly
- Updated the _'ProcFwkComponents.json'_ file to include the Email Sender pipeline in the deployment
- Fixed a bug in the procedure _'Check For Email Parts'_ where emails aren't sent if recipients choose to get All alerts and pipeline finishes with a Status Success