### PR TITLE
Issue 87 - Switch Email Alerting Call to Use Utils Pipeline

### DIFF
--- a/DataFactory/pipeline/04-Infant.json
+++ b/DataFactory/pipeline/04-Infant.json
@@ -396,8 +396,7 @@
 						},
 						{
 							"name": "Send Email",
-							"description": "Use an Azure Function to perform an SMTP client email send operation.",
-							"type": "AzureFunctionActivity",
+							"type": "ExecutePipeline",
 							"dependsOn": [
 								{
 									"activity": "Get Email Parts",
@@ -406,25 +405,39 @@
 									]
 								}
 							],
-							"policy": {
-								"timeout": "0.00:10:00",
-								"retry": 0,
-								"retryIntervalInSeconds": 30,
-								"secureOutput": false,
-								"secureInput": true
-							},
 							"userProperties": [],
 							"typeProperties": {
-								"functionName": "SendEmail",
-								"method": "POST",
-								"body": {
-									"value": "@activity('Get Email Parts').output.firstRow",
-									"type": "Expression"
+								"pipeline": {
+									"referenceName": "Email Sender",
+									"type": "PipelineReference"
+								},
+								"waitOnCompletion": true,
+								"parameters": {
+									"Recipients": {
+										"value": "@activity('Get Email Parts').output.firstRow.emailRecipients",
+										"type": "Expression"
+									},
+									"CcRecipients": {
+										"value": "@activity('Get Email Parts').output.firstRow.emailCcRecipients",
+										"type": "Expression"
+									},
+									"BccRecipients": {
+										"value": "@activity('Get Email Parts').output.firstRow.emailBccRecipients",
+										"type": "Expression"
+									},
+									"Subject": {
+										"value": "@activity('Get Email Parts').output.firstRow.emailSubject",
+										"type": "Expression"
+									},
+									"Body": {
+										"value": "@activity('Get Email Parts').output.firstRow.emailBody",
+										"type": "Expression"
+									},
+									"Importance": {
+										"value": "@activity('Get Email Parts').output.firstRow.emailImportance",
+										"type": "Expression"
+									}
 								}
-							},
-							"linkedServiceName": {
-								"referenceName": "FrameworkFunctions",
-								"type": "LinkedServiceReference"
 							}
 						}
 					]

--- a/DeploymentTools/DataFactory/ProcFwkComponents.json
+++ b/DeploymentTools/DataFactory/ProcFwkComponents.json
@@ -13,7 +13,8 @@
     "/pipeline/02-Parent.json",
     "/pipeline/01-Grandparent.json",
     "/pipeline/Throw Exception.json",
-    "/pipeline/Check For Running Pipeline.json"
+    "/pipeline/Check For Running Pipeline.json",
+    "/pipeline/Email Sender.json"
   ],
   "triggers": [
     "/trigger/FunctionalTestingTrigger.json"

--- a/MetadataDB/procfwk/Stored Procedures/CheckForEmailAlerts.sql
+++ b/MetadataDB/procfwk/Stored Procedures/CheckForEmailAlerts.sql
@@ -28,7 +28,10 @@ BEGIN
 				INNER JOIN procfwk.Recipients AS r
 					ON r.RecipientId = pal.RecipientId
 				WHERE ce.PipelineId = @PipelineId
-					  AND ao.BitValue & pal.OutcomesBitValue > 0
+					   AND (
+						ao.BitValue & pal.OutcomesBitValue <> 0
+						OR pal.OutcomesBitValue & 1 <> 0 --all
+						)
 					  AND pal.[Enabled] = 1
 					  AND r.[Enabled] = 1
 				)

--- a/ProcessingFramework.sln
+++ b/ProcessingFramework.sln
@@ -120,6 +120,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FactoryTesting", "FactoryTe
 EndProject
 Project("{00D1A9C2-B5F0-4AF3-8072-F6C62B433612}") = "MetadataDBTests", "MetadataDBTests\MetadataDBTests.sqlproj", "{32D54B90-932D-44A3-911D-007C4B90BC55}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_ProcFwkUtils", "_ProcFwkUtils", "{6809EDBD-125D-440E-8486-9CFAB9BB5B7D}"
+	ProjectSection(SolutionItems) = preProject
+		DataFactory\pipeline\Check For Running Pipeline.json = DataFactory\pipeline\Check For Running Pipeline.json
+		DataFactory\pipeline\Email Sender.json = DataFactory\pipeline\Email Sender.json
+		DataFactory\pipeline\Intentional Error.json = DataFactory\pipeline\Intentional Error.json
+		DataFactory\pipeline\Throw Exception.json = DataFactory\pipeline\Throw Exception.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -165,6 +173,7 @@ Global
 		{EBC230DF-D45D-43E4-A74E-32ADA3DDAE7A} = {5A56A63A-351D-467D-A2DA-FDB3C9CBD252}
 		{20313ECA-118E-408D-BB42-8094A7A9CD20} = {CC7B607B-8C84-4E07-A6C8-326923752F92}
 		{463330CD-189F-42B4-984A-8D3C1385645B} = {CC7B607B-8C84-4E07-A6C8-326923752F92}
+		{6809EDBD-125D-440E-8486-9CFAB9BB5B7D} = {17586826-8BE9-4622-B12E-1683F2A20352}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {170F5302-BB9C-4569-8F43-D859C7678EF0}


### PR DESCRIPTION
Made the following changes for issue #87 

- Added the 4 'ProcFwkUtils' pipelines to the solution
- Changed pipeline '04-Infant' to call the new pipeline 'Email Sender' instead of calling the Azure Function directly
- Updated the 'ProcFwkComponents.json' file to include the Email Sender pipeline in the deployment
- Fixed a bug in the procedure 'Check For Email Parts' where emails aren't sent if recipients choose to get All alerts and pipeline finishes with a Status Success